### PR TITLE
Game: Fix notelocking

### DIFF
--- a/public/src/js/controller.js
+++ b/public/src/js/controller.js
@@ -220,7 +220,7 @@ class Controller{
 		if(this.multiplayer){
 			p2.play(circle, this.mekadon)
 		}else{
-			this.mekadon.play(circle)
+			return this.mekadon.play(circle)
 		}
 	}
 	clean(){

--- a/public/src/js/mekadon.js
+++ b/public/src/js/mekadon.js
@@ -16,11 +16,11 @@ class Mekadon{
 		}
 		type = circle.type
 		if(type === "balloon"){
-			this.playDrumrollAt(circle, 0, 30)
+			return this.playDrumrollAt(circle, 0, 30)
 		}else if(type === "drumroll" || type === "daiDrumroll"){
-			this.playDrumrollAt(circle, 0, 60)
+			return this.playDrumrollAt(circle, 0, 60)
 		}else{
-			this.playAt(circle, 0, 450)
+			return this.playAt(circle, 0, 450)
 		}
 	}
 	playAt(circle, ms, score, dai, reverse){
@@ -35,7 +35,7 @@ class Mekadon{
 			if(kaAmount > 0){
 				score = Math.random() > kaAmount ? 1 : 2
 			}
-			this.playAt(circle, ms, score)
+			return this.playAt(circle, ms, score)
 		}
 	}
 	miss(circle){

--- a/public/src/js/parseosu.js
+++ b/public/src/js/parseosu.js
@@ -181,7 +181,8 @@ class ParseOsu{
 				measures.push({
 					ms: ms,
 					originalMS: ms,
-					speed: speed
+					speed: speed,
+					visible: true
 				})
 			}
 		}

--- a/public/src/js/view.js
+++ b/public/src/js/view.js
@@ -1100,7 +1100,7 @@
 		var songSkinName = selectedSong.songSkin.name
 		var supportsBlend = "mixBlendMode" in this.songBg.style
 		var songLayers = [document.getElementById("layer1"), document.getElementById("layer2")]
-		var prefix = selectedSong.songSkin.prefix || ""
+		var prefix = ""
 		
 		if(selectedSong.category in this.categories){
 			var catId = this.categories[selectedSong.category].sort
@@ -1111,8 +1111,9 @@
 		if(!selectedSong.songSkin.song){
 			var id = selectedSong.songBg
 			this.songBg.classList.add("songbg-" + id)
-			this.setLayers(songLayers, prefix + "bg_song_" + id + (supportsBlend ? "" : "a"), supportsBlend)
+			this.setLayers(songLayers, "bg_song_" + id + (supportsBlend ? "" : "a"), supportsBlend)
 		}else if(selectedSong.songSkin.song !== "none"){
+			var prefix = selectedSong.songSkin.prefix || ""
 			var notStatic = selectedSong.songSkin.song !== "static"
 			if(notStatic){
 				this.songBg.classList.add("songbg-" + selectedSong.songSkin.song)
@@ -1123,6 +1124,7 @@
 		if(!selectedSong.songSkin.stage){
 			this.songStage.classList.add("song-stage-" + selectedSong.songStage)
 		}else if(selectedSong.songSkin.stage !== "none"){
+			var prefix = selectedSong.songSkin.prefix || ""
 			this.setBgImage(this.songStage, assets.image[prefix + "bg_stage_" + songSkinName].src)
 		}
 	}
@@ -1131,7 +1133,7 @@
 		var songSkinName = selectedSong.songSkin.name
 		var donLayers = []
 		var filename = !selectedSong.songSkin.don && this.multiplayer === 2 ? "bg_don2_" : "bg_don_"
-		var prefix = selectedSong.songSkin.prefix || ""
+		var prefix = ""
 		
 		this.donBg = document.createElement("div")
 		this.donBg.classList.add("donbg")
@@ -1150,10 +1152,11 @@
 		var asset1, asset2
 		if(!selectedSong.songSkin.don){
 			this.donBg.classList.add("donbg-" + selectedSong.donBg)
-			this.setLayers(donLayers, prefix + filename + selectedSong.donBg, true)
+			this.setLayers(donLayers, filename + selectedSong.donBg, true)
 			asset1 = filename + selectedSong.donBg + "a"
 			asset2 = filename + selectedSong.donBg + "b"
 		}else if(selectedSong.songSkin.don !== "none"){
+			var prefix = selectedSong.songSkin.prefix || ""
 			var notStatic = selectedSong.songSkin.don !== "static"
 			if(notStatic){
 				this.donBg.classList.add("donbg-" + selectedSong.songSkin.don)


### PR DESCRIPTION
- Will not skip the note if `ka` was pressed right before `don` note or `don` was pressed right before `ka` note
- Will still skip the note if `don` and `ka` is pressed at the same time (within 25ms)
- A long stream of notes will snap to the nearest OK if the current note results in a BAD
- Improved mekadon hitting speed in high bpm meme charts
- Fixed `TAIKOWEBSKIN:` in imported songs crashing the game with some values