### PR TITLE
improve Dais for Taiko Force Lv5

### DIFF
--- a/public/src/js/controller.js
+++ b/public/src/js/controller.js
@@ -60,6 +60,7 @@ class Controller{
 		this.view = new View(this)
 		this.mekadon = new Mekadon(this, this.game)
 		this.keyboard = new GameInput(this)
+		this.TaikoForceLv5 = this.keyboard.keyboard.TaikoForceLv5 && !autoPlayEnabled && (this.multiplayer !== 2);
 		
 		this.drumSounds = settings.getItem("latency").drumSounds
 		this.playedSounds = {}

--- a/public/src/js/controller.js
+++ b/public/src/js/controller.js
@@ -60,7 +60,11 @@ class Controller{
 		this.view = new View(this)
 		this.mekadon = new Mekadon(this, this.game)
 		this.keyboard = new GameInput(this)
-		this.TaikoForceLv5 = this.keyboard.keyboard.TaikoForceLv5 && !autoPlayEnabled && (this.multiplayer !== 2);
+		if(!autoPlayEnabled && this.multiplayer !== 2){
+			this.easierBigNotes = settings.getItem("easierBigNotes") || this.keyboard.keyboard.TaikoForceLv5
+		}else{
+			this.easierBigNotes = false
+		}
 		
 		this.drumSounds = settings.getItem("latency").drumSounds
 		this.playedSounds = {}

--- a/public/src/js/game.js
+++ b/public/src/js/game.js
@@ -330,8 +330,10 @@ class Game{
 			}
 			var score = 0
 			if(keysDon && typeDon || keysKa && typeKa){
-				if(typeDai && !keyDai){
-					if(!circle.daiFailed){
+				if (typeDai && !keyDai) {
+					if (this.controller.TaikoForceLv5) { // Taiko Force Lv5 can't hit both Dons at the same time, so dai offered
+						keyDai = true;
+					} else if(!circle.daiFailed){
 						circle.daiFailed = ms
 						return false
 					}else if(ms < circle.daiFailed + this.rules.daiLeniency){

--- a/public/src/js/game.js
+++ b/public/src/js/game.js
@@ -31,7 +31,6 @@ class Game{
 		this.branchNames = ["normal", "advanced", "master"]
 		this.resetSection()
 		this.gameLagSync = !this.controller.touchEnabled && !(/Firefox/.test(navigator.userAgent))
-		this.lastPressedKeys = [false, false, false, false]
 		
 		assets.songs.forEach(song => {
 			if(song.id == selectedSong.folder){
@@ -105,7 +104,9 @@ class Game{
 						circle.beatMSCopied = true
 					}
 				}
-				if(ms > endTime){
+				if(circle.daiFailed && (ms >= circle.daiFailed.ms + this.rules.daiLeniency || ms > endTime)){
+					this.checkScore(circle, circle.daiFailed.check)
+				}else if(ms > endTime){
 					if(!this.controller.autoPlayEnabled){
 						if(drumrollNotes){
 							if(circle.section && circle.timesHit === 0){
@@ -265,11 +266,6 @@ class Game{
 		var don_r = keys["don_r"] && !this.controller.isWaiting("don_r", "score")
 		var ka_l = keys["ka_l"] && !this.controller.isWaiting("ka_l", "score")
 		var ka_r = keys["ka_r"] && !this.controller.isWaiting("ka_r", "score")
-		if(don_l || don_r || ka_l || ka_r){
-			this.lastPressedKeys = [don_l, don_r, ka_l, ka_r]
-		}else{
-			[don_l, don_r, ka_l, ka_r] = this.lastPressedKeys
-		}
 		
 		var checkDon = () => {
 			if(don_l && don_r){
@@ -320,7 +316,7 @@ class Game{
 		var typeDai = type === "daiDon" || type === "daiKa"
 		
 		var keyTime = this.controller.getKeyTime()
-		var currentTime = keysDon ? keyTime["don"] : keyTime["ka"]
+		var currentTime = circle.daiFailed ? circle.daiFailed.ms : keysDon ? keyTime["don"] : keyTime["ka"]
 		var relative = currentTime - circle.ms - this.controller.audioLatency
 		
 		if(relative >= this.rules.ok){
@@ -336,17 +332,6 @@ class Game{
 			}
 			var score = 0
 			if(keysDon && typeDon || keysKa && typeKa){
-				if(typeDai && !keyDai){
-					if(this.controller.easierBigNotes){
-						// Taiko Force Lv5 can't hit both Dons at the same time, so dai offered
-						keyDai = true
-					}else if(!circle.daiFailed){
-						circle.daiFailed = ms
-						return false
-					}else if(ms < circle.daiFailed + this.rules.daiLeniency){
-						return false
-					}
-				}
 				var circleStatus = -1
 				relative = Math.abs(relative)
 				if(relative < this.rules.good){
@@ -355,6 +340,23 @@ class Game{
 					circleStatus = 230
 				}else if(relative < this.rules.bad){
 					circleStatus = 0
+				}
+				if(typeDai && !keyDai){
+					if(this.controller.easierBigNotes){
+						// Taiko Force Lv5 can't hit both Dons at the same time, so dai offered
+						keyDai = true
+					}else if(!circle.daiFailed){
+						circle.daiFailed = {
+							ms: ms,
+							status: circleStatus,
+							check: check
+						}
+						return false
+					}else if(ms < circle.daiFailed.ms + this.rules.daiLeniency){
+						return false
+					}else{
+						circleStatus = circle.daiFailed.status
+					}
 				}
 				if(circleStatus === 230 || circleStatus === 450){
 					score = circleStatus

--- a/public/src/js/game.js
+++ b/public/src/js/game.js
@@ -31,6 +31,7 @@ class Game{
 		this.branchNames = ["normal", "advanced", "master"]
 		this.resetSection()
 		this.gameLagSync = !this.controller.touchEnabled && !(/Firefox/.test(navigator.userAgent))
+		this.lastPressedKeys = [false, false, false, false]
 		
 		assets.songs.forEach(song => {
 			if(song.id == selectedSong.folder){
@@ -264,6 +265,11 @@ class Game{
 		var don_r = keys["don_r"] && !this.controller.isWaiting("don_r", "score")
 		var ka_l = keys["ka_l"] && !this.controller.isWaiting("ka_l", "score")
 		var ka_r = keys["ka_r"] && !this.controller.isWaiting("ka_r", "score")
+		if(don_l || don_r || ka_l || ka_r){
+			this.lastPressedKeys = [don_l, don_r, ka_l, ka_r]
+		}else{
+			[don_l, don_r, ka_l, ka_r] = this.lastPressedKeys
+		}
 		
 		var checkDon = () => {
 			if(don_l && don_r){
@@ -330,10 +336,11 @@ class Game{
 			}
 			var score = 0
 			if(keysDon && typeDon || keysKa && typeKa){
-				if (typeDai && !keyDai) {
-					if (this.controller.TaikoForceLv5) { // Taiko Force Lv5 can't hit both Dons at the same time, so dai offered
-						keyDai = true;
-					} else if(!circle.daiFailed){
+				if(typeDai && !keyDai){
+					if(this.controller.easierBigNotes){
+						// Taiko Force Lv5 can't hit both Dons at the same time, so dai offered
+						keyDai = true
+					}else if(!circle.daiFailed){
 						circle.daiFailed = ms
 						return false
 					}else if(ms < circle.daiFailed + this.rules.daiLeniency){

--- a/public/src/js/keyboard.js
+++ b/public/src/js/keyboard.js
@@ -14,12 +14,19 @@ class Keyboard{
 			"altgr": "altgraph"
 		}
 		this.btn = {}
+		this.TaikoForceLv5 = false;
 		this.update()
 		pageEvents.keyAdd(this, "all", "both", this.keyEvent.bind(this))
 		pageEvents.blurAdd(this, this.blurEvent.bind(this))
 	}
+	isTaikoForceLv5(kbdSettings) { // the key of Taiko Force Lv5's PC module looks like this
+		//console.log(kbdSettings);
+		return (kbdSettings.ka_l[0] === "f") && (kbdSettings.ka_r[0] === "e") && (kbdSettings.don_l[0] === "i") && (kbdSettings.don_r[0] === "j");
+	}
 	update(){
 		var kbdSettings = settings.getItem("keyboardSettings")
+		this.TaikoForceLv5 = this.isTaikoForceLv5(kbdSettings);
+		//console.log("Taiko Force Lv5", this.TaikoForceLv5);
 		var drumKeys = {}
 		for(var name in kbdSettings){
 			var keys = kbdSettings[name]

--- a/public/src/js/keyboard.js
+++ b/public/src/js/keyboard.js
@@ -19,14 +19,13 @@ class Keyboard{
 		pageEvents.keyAdd(this, "all", "both", this.keyEvent.bind(this))
 		pageEvents.blurAdd(this, this.blurEvent.bind(this))
 	}
-	isTaikoForceLv5(kbdSettings) { // the key of Taiko Force Lv5's PC module looks like this
-		//console.log(kbdSettings);
+	isTaikoForceLv5(kbdSettings){
+		// the key of Taiko Force Lv5's PC module looks like this
 		return (kbdSettings.ka_l[0] === "f") && (kbdSettings.ka_r[0] === "e") && (kbdSettings.don_l[0] === "i") && (kbdSettings.don_r[0] === "j");
 	}
 	update(){
 		var kbdSettings = settings.getItem("keyboardSettings")
-		this.TaikoForceLv5 = this.isTaikoForceLv5(kbdSettings);
-		//console.log("Taiko Force Lv5", this.TaikoForceLv5);
+		this.TaikoForceLv5 = this.isTaikoForceLv5(kbdSettings)
 		var drumKeys = {}
 		for(var name in kbdSettings){
 			var keys = kbdSettings[name]

--- a/public/src/js/settings.js
+++ b/public/src/js/settings.js
@@ -46,6 +46,10 @@ class Settings{
 					"video": 0,
 					"drumSounds": true
 				}
+			},
+			easierBigNotes: {
+				type: "toggle",
+				default: false
 			}
 		}
 		

--- a/public/src/js/strings.js
+++ b/public/src/js/strings.js
@@ -151,6 +151,9 @@
 			video: "Video",
 			drumSounds: "Drum Sounds"
 		},
+		easierBigNotes: {
+			name: "大きな音符を簡単にする"
+		},
 		on: "オン",
 		off: "オフ",
 		default: "既定値にリセット",
@@ -342,6 +345,9 @@ function StringsEn(){
 			audio: "Audio",
 			video: "Video",
 			drumSounds: "Drum Sounds"
+		},
+		easierBigNotes: {
+			name: "Easier Big Notes"
 		},
 		on: "On",
 		off: "Off",
@@ -535,6 +541,9 @@ function StringsCn(){
 			video: "Video",
 			drumSounds: "Drum Sounds"
 		},
+		easierBigNotes: {
+			name: "使大音符变得容易"
+		},
 		on: "开",
 		off: "关",
 		default: "重置为默认值",
@@ -727,6 +736,9 @@ function StringsTw(){
 			video: "Video",
 			drumSounds: "Drum Sounds"
 		},
+		easierBigNotes: {
+			name: "使大音符變得容易"
+		},
 		on: "開",
 		off: "關",
 		default: "重置為默認值",
@@ -918,6 +930,9 @@ function StringsKo(){
 			audio: "Audio",
 			video: "Video",
 			drumSounds: "Drum Sounds"
+		},
+		easierBigNotes: {
+			name: "쉬운 큰 음표"
 		},
 		on: "온",
 		off: "오프",

--- a/public/src/js/strings.js
+++ b/public/src/js/strings.js
@@ -152,7 +152,7 @@
 			drumSounds: "Drum Sounds"
 		},
 		easierBigNotes: {
-			name: "大きな音符を簡単にする"
+			name: "簡単な大きな音符"
 		},
 		on: "オン",
 		off: "オフ",
@@ -542,7 +542,7 @@ function StringsCn(){
 			drumSounds: "Drum Sounds"
 		},
 		easierBigNotes: {
-			name: "使大音符变得容易"
+			name: "简单的大音符"
 		},
 		on: "开",
 		off: "关",
@@ -737,7 +737,7 @@ function StringsTw(){
 			drumSounds: "Drum Sounds"
 		},
 		easierBigNotes: {
-			name: "使大音符變得容易"
+			name: "簡單的大音符"
 		},
 		on: "開",
 		off: "關",


### PR DESCRIPTION
Fixed this: Dai Dons or Kas can't be hit when playing with Taiko Force Lv5. This occurs because Taiko Force Lv5 can only hit one face once.
Since Dai is judged by hitting with power rather than by both hands, the Dais would be offered free when using Taiko Force Lv5. Perhaps there would be a better solution than this.
In fact, Taiko Force Lv5 has 2 modes: single mode and free mode. Single mode only allows one face be hit in a single time. Free mode does not limit this, but some unexpected behavior, such as misjudged Kas as Dons, would occur. This PR allows Lv5 be played in single mode in Lv5.
 In addition, this PR detects whether player uses Taiko Force Lv5 by key config because Lv5 uses that key and it cannot be changed. There may be better solutions.
~~I spent 300 USD for this PR~~