### PR TITLE
ImportSongs: Add Google Drive support

### DIFF
--- a/app.py
+++ b/app.py
@@ -119,7 +119,8 @@ def get_config():
         'assets_baseurl': config.ASSETS_BASEURL,
         'email': config.EMAIL,
         'accounts': config.ACCOUNTS,
-        'custom_js': config.CUSTOM_JS
+        'custom_js': config.CUSTOM_JS,
+        'google_credentials': config.GOOGLE_CREDENTIALS
     }
 
     if not config_out.get('songs_baseurl'):

--- a/config.example.py
+++ b/config.example.py
@@ -33,3 +33,11 @@ SECRET_KEY = 'change-me'
 
 # Git repository base URL.
 URL = 'https://github.com/bui/taiko-web/'
+
+# Google Drive API.
+GOOGLE_CREDENTIALS = {
+    'gdrive_enabled': False,
+    'api_key': '',
+    'oauth_client_id': '',
+    'project_number': ''
+}

--- a/public/src/css/loadsong.css
+++ b/public/src/css/loadsong.css
@@ -13,8 +13,8 @@
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	width: 20vw;
-	height: 15vw;
+	width: 20vmax;
+	height: 15vmax;
 	background: rgba(0, 0, 0, 0.75);
 	border-radius: 5px;
 	border: 3px solid white;
@@ -22,14 +22,14 @@
 	z-index: 1;
 }
 #loading-don{
-	width: 10vw;
-	height: calc(10vw / 120 * 115);
+	width: 10vmax;
+	height: calc(10vmax / 120 * 115);
 	background-size: contain;
 	background-repeat: no-repeat;
 }
 .loading-text{
 	position: relative;
-	font-size: 1.5vw;
+	font-size: 1.5vmax;
 	text-align: center;
 	z-index: 1;
 }

--- a/public/src/css/loadsong.css
+++ b/public/src/css/loadsong.css
@@ -19,6 +19,7 @@
 	border-radius: 5px;
 	border: 3px solid white;
 	color: #fff;
+	z-index: 1;
 }
 #loading-don{
 	width: 10vw;

--- a/public/src/css/view.css
+++ b/public/src/css/view.css
@@ -108,6 +108,14 @@ kbd{
 .left-buttons .taibtn{
 	margin-right: 0.4em;
 }
+.center-buttons{
+	display: flex;
+	justify-content: center;
+	margin: 1.5em 0;
+}
+.center-buttons .taibtn{
+	margin: 0 0.2em;
+}
 .diag-txt textarea,
 .diag-txt iframe{
 	width: 100%;
@@ -217,7 +225,8 @@ kbd{
 	z-index: 1;
 }
 #settings-gamepad,
-#settings-latency{
+#settings-latency,
+#customsongs-error{
 	display: none;
 }
 #settings-gamepad .view{
@@ -289,7 +298,8 @@ kbd{
 .latency-buttons span:active{
 	background-color: #946013;
 }
-.left-buttons .taibtn{
+.left-buttons .taibtn,
+.center-buttons .taibtn{
 	z-index: 1;
 }
 .accountpass-form,
@@ -402,4 +412,20 @@ kbd{
 	font-family: inherit;
 	font-size: 1em;
 	padding: 0.2em;
+}
+#customsongs-error .view,
+#dropzone .view{
+	width: 600px;
+}
+#dropzone{
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 0.5s;
+}
+#dropzone .view-content{
+	font-size: 2em;
+	text-align: center;
+}
+#dropzone.dragover{
+	opacity: 1;
 }

--- a/public/src/js/about.js
+++ b/public/src/js/about.js
@@ -138,7 +138,7 @@
 				if(gamepads[i]){
 					var gamepadDiag = []
 					gamepadDiag.push(gamepads[i].id)
-					gamepadDiag.push("buttons: " + 	gamepads[i].buttons.length)
+					gamepadDiag.push("buttons: " + gamepads[i].buttons.length)
 					gamepadDiag.push("axes: " + gamepads[i].axes.length)
 					diag.push("Gamepad #" + (i + 1) + ": " + gamepadDiag.join(", "))
 				}

--- a/public/src/js/abstractfile.js
+++ b/public/src/js/abstractfile.js
@@ -38,9 +38,9 @@ class RemoteFile{
 	}
 }
 class LocalFile{
-	constructor(file){
+	constructor(file, path){
 		this.file = file
-		this.path = file.webkitRelativePath
+		this.path = path || file.webkitRelativePath
 		this.url = this.path
 		this.name = file.name
 	}

--- a/public/src/js/abstractfile.js
+++ b/public/src/js/abstractfile.js
@@ -62,9 +62,12 @@ class GdriveFile{
 	}
 	read(encoding){
 		if(encoding){
-			return this.arrayBuffer().then(response =>
-				new TextDecoder(encoding).decode(response)
-			)
+			return this.arrayBuffer().then(response => {
+				var reader = new FileReader()
+				var promise = pageEvents.load(reader).then(event => event.target.result)
+				reader.readAsText(new Blob([response]), encoding)
+				return promise
+			})
 		}else{
 			return gpicker.downloadFile(this.id)
 		}

--- a/public/src/js/abstractfile.js
+++ b/public/src/js/abstractfile.js
@@ -1,0 +1,87 @@
+class RemoteFile{
+	constructor(url){
+		this.url = url
+		try{
+			this.path = new URL(url).pathname
+		}catch(e){
+			this.path = url
+		}
+		if(this.path.startsWith("/")){
+			this.path = this.path.slice(1)
+		}
+		this.name = this.path
+		var index = this.name.lastIndexOf("/")
+		if(index !== -1){
+			this.name = this.name.slice(index + 1)
+		}
+	}
+	arrayBuffer(){
+		return loader.ajax(this.url, request => {
+			request.responseType = "arraybuffer"
+		})
+	}
+	read(encoding){
+		if(encoding){
+			return this.arrayBuffer().then(response =>
+				new TextDecoder(encoding).decode(response)
+			)
+		}else{
+			return loader.ajax(this.url)
+		}
+	}
+}
+class LocalFile{
+	constructor(file){
+		this.file = file
+		this.path = file.webkitRelativePath
+		this.url = this.path
+		this.name = file.name
+	}
+	arrayBuffer(){
+		var reader = new FileReader()
+		var promise = pageEvents.load(reader).then(event => event.target.result)
+		reader.readAsArrayBuffer(this.file)
+		return promise
+	}
+	read(encoding){
+		var reader = new FileReader()
+		var promise = pageEvents.load(reader).then(event => event.target.result)
+		reader.readAsText(this.file, encoding)
+		return promise
+	}
+}
+class GdriveFile{
+	constructor(fileObj){
+		this.path = fileObj.path
+		this.name = fileObj.name
+		this.id = fileObj.id
+		this.url = gpicker.filesUrl + this.id + "?alt=media"
+	}
+	arrayBuffer(){
+		return gpicker.downloadFile(this.id, true)
+	}
+	read(encoding){
+		if(encoding){
+			return this.arrayBuffer().then(response =>
+				new TextDecoder(encoding).decode(response)
+			)
+		}else{
+			return gpicker.downloadFile(this.id)
+		}
+	}
+}
+class CachedFile{
+	constructor(contents, oldFile){
+		this.contents = contents
+		this.oldFile = oldFile
+		this.path = oldFile.path
+		this.name = oldFile.name
+		this.url = oldFile.url
+	}
+	arrayBuffer(){
+		return Promise.resolve(this.contents)
+	}
+	read(encoding){
+		return this.arrayBuffer()
+	}
+}

--- a/public/src/js/assets.js
+++ b/public/src/js/assets.js
@@ -33,7 +33,9 @@ var assets = {
 		"settings.js",
 		"scorestorage.js",
 		"account.js",
-		"lyrics.js"
+		"lyrics.js",
+		"customsongs.js",
+		"abstractfile.js"
 	],
 	"css": [
 		"main.css",
@@ -144,7 +146,8 @@ var assets = {
 		"session.html",
 		"settings.html",
 		"account.html",
-		"login.html"
+		"login.html",
+		"customsongs.html"
 	],
 	
 	"songs": [],

--- a/public/src/js/autoscore.js
+++ b/public/src/js/autoscore.js
@@ -165,7 +165,6 @@ class AutoScore {
 	GetMaxCombo() { 
 		var combo = 0;
 		for (var circle of this.circles) { 
-			//alert(this.IsCommonCircle(circle));
 			if (this.IsCommonCircle(circle) && (!circle.branch || circle.branch.name === "master")) { 
 				combo++;
 			}

--- a/public/src/js/controller.js
+++ b/public/src/js/controller.js
@@ -40,12 +40,12 @@ class Controller{
 			this.parsedSongData = new ParseOsu(songData, selectedSong.difficulty, selectedSong.stars, selectedSong.offset)
 		}
 		this.offset = this.parsedSongData.soundOffset
-
+		
 		var maxCombo = this.parsedSongData.circles.filter(circle => ["don", "ka", "daiDon", "daiKa"].indexOf(circle.type) > -1 && (!circle.branch || circle.branch.name == "master")).length
 		if (maxCombo >= 50) {
-			var comboVoices = ["v_combo_50"].concat([...Array(Math.floor(maxCombo/100)).keys()].map(i => "v_combo_" + (i + 1)*100))
+			var comboVoices = ["v_combo_50"].concat(Array.from(Array(Math.min(50, Math.floor(maxCombo / 100))), (d, i) => "v_combo_" + ((i + 1) * 100)))
 			var promises = []
-
+			
 			comboVoices.forEach(name => {
 				if (!assets.sounds[name + "_p1"]) {
 					promises.push(loader.loadSound(name + ".wav", snd.sfxGain).then(sound => {
@@ -54,7 +54,7 @@ class Controller{
 					}))
 				}
 			})
-
+			
 			Promise.all(promises)
 		}
 		

--- a/public/src/js/controller.js
+++ b/public/src/js/controller.js
@@ -246,23 +246,15 @@ class Controller{
 					var songObj = assets.songs.find(song => song.id === this.selectedSong.folder)
 					var promises = []
 					if(songObj.chart && songObj.chart !== "blank"){
-						var reader = new FileReader()
-						promises.push(pageEvents.load(reader).then(event => {
-							this.songData = event.target.result.replace(/\0/g, "").split("\n")
+						promises.push(songObj.chart.read(this.selectedSong.type === "tja" ? "sjis" : undefined).then(data => {
+							this.songData = data.replace(/\0/g, "").split("\n")
 							return Promise.resolve()
 						}))
-						if(this.selectedSong.type === "tja"){
-							reader.readAsText(songObj.chart, "sjis")
-						}else{
-							reader.readAsText(songObj.chart)
-						}
 					}
 					if(songObj.lyricsFile){
-						var reader = new FileReader()
-						promises.push(pageEvents.load(reader).then(event => {
+						promises.push(songObj.lyricsFile.read().then(event => {
 							songObj.lyricsData = event.target.result
-						}, () => Promise.resolve()), songObj.lyricsFile.webkitRelativePath)
-						reader.readAsText(songObj.lyricsFile)
+						}, () => Promise.resolve()), songObj.lyricsFile.path)
 					}
 					Promise.all(promises).then(resolve)
 				}

--- a/public/src/js/controller.js
+++ b/public/src/js/controller.js
@@ -252,8 +252,8 @@ class Controller{
 						}))
 					}
 					if(songObj.lyricsFile){
-						promises.push(songObj.lyricsFile.read().then(event => {
-							songObj.lyricsData = event.target.result
+						promises.push(songObj.lyricsFile.read().then(result => {
+							songObj.lyricsData = result
 						}, () => Promise.resolve()), songObj.lyricsFile.path)
 					}
 					Promise.all(promises).then(resolve)

--- a/public/src/js/customsongs.js
+++ b/public/src/js/customsongs.js
@@ -1,0 +1,216 @@
+class CustomSongs{
+	constructor(touchEnabled){
+		this.touchEnabled = touchEnabled
+		loader.changePage("customsongs", true)
+		if(touchEnabled){
+			this.getElement("view-outer").classList.add("touch-enabled")
+		}
+		this.locked = false
+		
+		var tutorialTitle = this.getElement("view-title")
+		this.setAltText(tutorialTitle, strings.customSongs.title)
+		
+		var tutorialContent = this.getElement("view-content")
+		strings.customSongs.description.forEach(string => {
+			tutorialContent.appendChild(document.createTextNode(string))
+			tutorialContent.appendChild(document.createElement("br"))
+		})
+		
+		this.items = []
+		this.linkLocalFolder = document.getElementById("link-localfolder")
+		this.hasLocal = "webkitdirectory" in HTMLInputElement.prototype && !(/Android/.test(navigator.userAgent))
+		if(this.hasLocal){
+			this.browse = document.getElementById("browse")
+			pageEvents.add(this.browse, "change", this.browseChange.bind(this))
+			this.setAltText(this.linkLocalFolder, strings.customSongs.localFolder)
+			pageEvents.add(this.linkLocalFolder, ["mousedown", "touchstart"], this.localFolder.bind(this))
+			this.items.push(this.linkLocalFolder)
+		}else{
+			this.linkLocalFolder.parentNode.removeChild(this.linkLocalFolder)
+		}
+		
+		this.linkGdriveFolder = document.getElementById("link-gdrivefolder")
+		if(gameConfig.google_credentials.gdrive_enabled){
+			this.setAltText(this.linkGdriveFolder, strings.customSongs.gdriveFolder)
+			pageEvents.add(this.linkGdriveFolder, ["mousedown", "touchstart"], this.gdriveFolder.bind(this))
+			this.items.push(this.linkGdriveFolder)
+		}else{
+			this.linkGdriveFolder.parentNode.removeChild(this.linkGdriveFolder)
+		}
+		
+		this.endButton = this.getElement("view-end-button")
+		this.setAltText(this.endButton, strings.session.cancel)
+		pageEvents.add(this.endButton, ["mousedown", "touchstart"], this.onEnd.bind(this))
+		this.items.push(this.endButton)
+		this.selected = this.items.length - 1
+		
+		this.loaderDiv = document.createElement("div")
+		this.loaderDiv.innerHTML = assets.pages["loadsong"]
+		var loadingText = this.loaderDiv.querySelector("#loading-text")
+		loadingText.appendChild(document.createTextNode(strings.loading))
+		loadingText.setAttribute("alt", strings.loading)
+		
+		this.keyboard = new Keyboard({
+			confirm: ["enter", "space", "don_l", "don_r"],
+			previous: ["left", "up", "ka_l"],
+			next: ["right", "down", "ka_r"],
+			back: ["escape"]
+		}, this.keyPressed.bind(this))
+		this.gamepad = new Gamepad({
+			confirmPad: ["b", "ls", "rs"],
+			previous: ["u", "l", "lb", "lt", "lsu", "lsl"],
+			next: ["d", "r", "rb", "rt", "lsd", "lsr"],
+			back: ["start", "a"]
+		}, this.keyPressed.bind(this))
+		
+		pageEvents.send("custom-songs")
+	}
+	getElement(name){
+		return loader.screen.getElementsByClassName(name)[0]
+	}
+	setAltText(element, text){
+		element.innerText = text
+		element.setAttribute("alt", text)
+	}
+	localFolder(){
+		if(this.locked){
+			return
+		}
+		this.browse.click()
+	}
+	browseChange(event){
+		var files = []
+		for(var i = 0; i < event.target.files.length; i++){
+			files.push(new LocalFile(event.target.files[i]))
+		}
+		if(!files.length){
+			return
+		}
+		this.locked = true
+		this.loading(true)
+		
+		var importSongs = new ImportSongs()
+		importSongs.load(files).then(this.songsLoaded.bind(this), e => {
+			this.browse.parentNode.reset()
+			this.locked = false
+			this.loading(false)
+			if(e !== "cancel"){
+				return Promise.reject(e)
+			}
+		})
+	}
+	gdriveFolder(){
+		if(this.locked){
+			return
+		}
+		this.locked = true
+		this.loading(true)
+		var importSongs = new ImportSongs(true)
+		if(!gpicker){
+			var gpickerPromise = loader.loadScript("/src/js/gpicker.js").then(() => {
+				gpicker = new Gpicker()
+			})
+		}else{
+			var gpickerPromise = Promise.resolve()
+		}
+		gpickerPromise.then(() => {
+			return gpicker.browse(locked => {
+				this.locked = locked
+				this.loading(locked)
+			})
+		}).then(files => importSongs.load(files))
+		.then(this.songsLoaded.bind(this))
+		.catch(e => {
+			this.locked = false
+			this.loading(false)
+			if(e !== "cancel"){
+				return Promise.reject(e)
+			}
+		})
+	}
+	loading(show){
+		if(show){
+			loader.screen.appendChild(this.loaderDiv)
+		}else{
+			loader.screen.removeChild(this.loaderDiv)
+		}
+	}
+	songsLoaded(songs){
+		var length = songs.length
+		assets.songs = songs
+		assets.customSongs = true
+		assets.customSelected = 0
+		assets.sounds["se_don"].play()
+		this.clean()
+		setTimeout(() => {
+			new SongSelect("customSongs", false, this.touchEnabled)
+			pageEvents.send("import-songs", length)
+		}, 500)
+	}
+	keyPressed(pressed, name){
+		if(!pressed || this.locked){
+			return
+		}
+		var selected = this.items[this.selected]
+		if(name === "confirm" || name === "confirmPad"){
+			if(selected === this.endButton){
+				this.onEnd()
+			}else if(name !== "confirmPad"){
+				if(selected === this.linkLocalFolder){
+					assets.sounds["se_don"].play()
+					this.localFolder()
+				}else if(selected === this.linkGdriveFolder){
+					assets.sounds["se_don"].play()
+					this.gdriveFolder()
+				}
+			}
+		}else if(name === "previous" || name === "next"){
+			selected.classList.remove("selected")
+			this.selected = this.mod(this.items.length, this.selected + (name === "next" ? 1 : -1))
+			this.items[this.selected].classList.add("selected")
+			assets.sounds["se_ka"].play()
+		}else if(name === "back"){
+			this.onEnd()
+		}
+	}
+	mod(length, index){
+		return ((index % length) + length) % length
+	}
+	onEnd(event){
+		if(this.locked){
+			return
+		}
+		var touched = false
+		if(event){
+			if(event.type === "touchstart"){
+				event.preventDefault()
+				touched = true
+			}else if(event.which !== 1){
+				return
+			}
+		}
+		this.clean()
+		assets.sounds["se_don"].play()
+		setTimeout(() => {
+			new SongSelect("customSongs", false, touched)
+		}, 500)
+	}
+	clean(){
+		this.keyboard.clean()
+		this.gamepad.clean()
+		pageEvents.remove(this.browse, "change")
+		if(this.hasLocal){
+			pageEvents.remove(this.linkLocalFolder, ["mousedown", "touchstart"])
+		}
+		if(gameConfig.google_credentials.gdrive_enabled){
+			pageEvents.remove(this.linkGdriveFolder, ["mousedown", "touchstart"])
+		}
+		pageEvents.remove(this.endButton, ["mousedown", "touchstart"])
+		delete this.browse
+		delete this.linkLocalFolder
+		delete this.linkGdriveFolder
+		delete this.endButton
+		delete this.items
+		delete this.loaderDiv
+	}
+}

--- a/public/src/js/customsongs.js
+++ b/public/src/js/customsongs.js
@@ -136,10 +136,12 @@ class CustomSongs{
 		}
 	}
 	songsLoaded(songs){
-		var length = songs.length
-		assets.songs = songs
-		assets.customSongs = true
-		assets.customSelected = 0
+		if(songs){
+			var length = songs.length
+			assets.songs = songs
+			assets.customSongs = true
+			assets.customSelected = 0
+		}
 		assets.sounds["se_don"].play()
 		this.clean()
 		setTimeout(() => {

--- a/public/src/js/customsongs.js
+++ b/public/src/js/customsongs.js
@@ -107,7 +107,7 @@ class CustomSongs{
 		element.innerText = text
 		element.setAttribute("alt", text)
 	}
-	localFolder(){
+	localFolder(event){
 		if(event){
 			if(event.type === "touchstart"){
 				event.preventDefault()

--- a/public/src/js/gpicker.js
+++ b/public/src/js/gpicker.js
@@ -21,6 +21,9 @@ class Gpicker{
 						for(var i = 0; i < files.length; i++){
 							var path = files[i].path ? files[i].path + "/" : ""
 							var list = files[i].list
+							if(!list){
+								continue
+							}
 							for(var j = 0; j < list.length; j++){
 								var file = list[j]
 								if(file.mimeType === this.folder){
@@ -68,7 +71,7 @@ class Gpicker{
 	}
 	loadApi(){
 		if(window.gapi && gapi.client && gapi.client.drive){
-			return
+			return Promise.resolve()
 		}
 		return loader.loadScript("https://apis.google.com/js/api.js")
 		.then(() => new Promise((resolve, reject) =>
@@ -83,7 +86,7 @@ class Gpicker{
 	}
 	getToken(lockedCallback){
 		if(this.oauthToken){
-			return
+			return Promise.resolve()
 		}
 		if(!this.auth){
 			var authPromise = gapi.auth2.init({

--- a/public/src/js/gpicker.js
+++ b/public/src/js/gpicker.js
@@ -1,0 +1,185 @@
+class Gpicker{
+	constructor(){
+		this.apiKey = gameConfig.google_credentials.api_key
+		this.oauthClientId = gameConfig.google_credentials.oauth_client_id
+		this.projectNumber = gameConfig.google_credentials.project_number
+		this.scope = "https://www.googleapis.com/auth/drive.readonly"
+		this.folder = "application/vnd.google-apps.folder"
+		this.filesUrl = "https://www.googleapis.com/drive/v3/files/"
+		this.resolveQueue = []
+		this.queueActive = false
+	}
+	browse(lockedCallback){
+		return this.loadApi()
+		.then(() => this.getToken(lockedCallback))
+		.then(() => new Promise((resolve, reject) => {
+			this.displayPicker(data => {
+				if(data.action === "picked"){
+					var file = data.docs[0]
+					var walk = (files, output=[]) => {
+						var batch = null
+						for(var i = 0; i < files.length; i++){
+							var path = files[i].path ? files[i].path + "/" : ""
+							var list = files[i].list
+							for(var j = 0; j < list.length; j++){
+								var file = list[j]
+								if(file.mimeType === this.folder){
+									if(!batch){
+										batch = gapi.client.newBatch()
+									}
+									batch.add(gapi.client.drive.files.list({
+										q: "'" + file.id + "' in parents",
+										orderBy: "name_natural"
+									}), {
+										id: path + file.name
+									})
+								}else{
+									output.push(new GdriveFile({
+										path: path + file.name,
+										name: file.name,
+										id: file.id
+									}))
+								}
+							}
+						}
+						if(batch){
+							return this.queue()
+							.then(() => batch.then(responses => {
+								var files = []
+								for(var path in responses.result){
+									files.push({path: path, list: responses.result[path].result.files})
+								}
+								return walk(files, output)
+							}))
+						}else{
+							return output
+						}
+					}
+					if(file.mimeType === this.folder){
+						return walk([{list: [file]}]).then(resolve, reject)
+					}else{
+						return reject("cancel")
+					}
+				}else if(data.action === "cancel"){
+					return reject("cancel")
+				}
+			})
+		}))
+	}
+	loadApi(){
+		if(window.gapi && gapi.client && gapi.client.drive){
+			return
+		}
+		return loader.loadScript("https://apis.google.com/js/api.js")
+		.then(() => new Promise((resolve, reject) =>
+			gapi.load("auth2:picker:client", {
+				callback: resolve,
+				onerror: reject
+			})
+		))
+		.then(() => new Promise((resolve, reject) =>
+			gapi.client.load("drive", "v3").then(resolve, reject)
+		))
+	}
+	getToken(lockedCallback){
+		if(this.oauthToken){
+			return
+		}
+		if(!this.auth){
+			var authPromise = gapi.auth2.init({
+				clientId: this.oauthClientId,
+				fetch_basic_profile: false,
+				scope: this.scope
+			}).then(() => {
+				this.auth = gapi.auth2.getAuthInstance()
+			}, e => {
+				if(e.details){
+					alert(strings.gpicker.authError.replace("%s", e.details))
+				}
+				return Promise.reject(e)
+			})
+		}else{
+			var authPromise = Promise.resolve()
+		}
+		return authPromise.then(() => {
+			var user = this.auth.currentUser.get()
+			if(!this.checkScope(user)){
+				lockedCallback(false)
+				this.auth.signIn().then(user => {
+					if(this.checkScope(user)){
+						lockedCallback(true)
+					}else{
+						return Promise.reject("cancel")
+					}
+				})
+			}
+		})
+	}
+	checkScope(user){
+		if(user.hasGrantedScopes(this.scope)){
+			this.oauthToken = user.getAuthResponse(true).access_token
+			return this.oauthToken
+		}else{
+			return false
+		}
+	}
+	displayPicker(callback){
+		var picker = gapi.picker.api
+		new picker.PickerBuilder()
+			.setDeveloperKey(this.apiKey)
+			.setAppId(this.projectNumber)
+			.setOAuthToken(this.oauthToken)
+			.hideTitleBar()
+			.addView(new picker.DocsView("folders")
+				.setLabel(strings.gpicker.myDrive)
+				.setParent("root")
+				.setSelectFolderEnabled(true)
+				.setMode("grid")
+			)
+			.addView(new picker.DocsView("folders")
+				.setLabel(strings.gpicker.starred)
+				.setStarred(true)
+				.setSelectFolderEnabled(true)
+				.setMode("grid")
+			)
+			.addView(new picker.DocsView("folders")
+				.setLabel(strings.gpicker.sharedWithMe)
+				.setOwnedByMe(false)
+				.setSelectFolderEnabled(true)
+				.setMode("list")
+			)
+			.setCallback(callback)
+			.setSize(Infinity, Infinity)
+			.build()
+			.setVisible(true)
+	}
+	downloadFile(id, arrayBuffer){
+		return this.queue().then(() =>
+			loader.ajax(this.filesUrl + id + "?alt=media", request => {
+				if(arrayBuffer){
+					request.responseType = "arraybuffer"
+				}
+				request.setRequestHeader("Authorization", "Bearer " + this.oauthToken)
+			})
+		)
+	}
+	queue(){
+		return new Promise(resolve => {
+			this.resolveQueue.push(resolve)
+			if(!this.queueActive){
+				this.queueActive = true
+				this.queueTimer = setInterval(this.parseQueue.bind(this), 100)
+				this.parseQueue()
+			}
+		})
+	}
+	parseQueue(){
+		if(this.resolveQueue.length){
+			var resolve = this.resolveQueue.shift()
+			resolve()
+		}else{
+			this.queueActive = false
+			clearInterval(this.queueTimer)
+		}
+	}
+}

--- a/public/src/js/importsongs.js
+++ b/public/src/js/importsongs.js
@@ -417,10 +417,13 @@
 					}
 				}))
 				image.id = name
-				image.src = URL.createObjectURL(file.blob())
+				promises.push(file.blob().then(blob => {
+					image.src = URL.createObjectURL(blob)
+				}))
 				loader.assetsDiv.appendChild(image)
 				var oldImage = assets.image[id]
 				if(oldImage && oldImage.parentNode){
+					URL.revokeObjectURL(oldImage.src)
 					oldImage.parentNode.removeChild(oldImage)
 				}
 				assets.image[id] = image
@@ -543,7 +546,7 @@
 		}else if(Object.keys(this.assetFiles).length){
 			return Promise.resolve()
 		}else{
-			return Promise.reject("cancel")
+			return Promise.reject("nosongs")
 		}
 		this.clean()
 	}

--- a/public/src/js/loader.js
+++ b/public/src/js/loader.js
@@ -156,7 +156,7 @@ class Loader{
 						}
 					}
 					if(song.lyrics){
-						song.lyricsFile = new RemoteFile(gameConfig.songs_baseurl + song.id + "main.vtt")
+						song.lyricsFile = new RemoteFile(directory + "main.vtt")
 					}
 					if(song.preview > 0){
 						song.previewMusic = new RemoteFile(directory + "preview.mp3")

--- a/public/src/js/loader.js
+++ b/public/src/js/loader.js
@@ -433,16 +433,19 @@ class Loader{
 		this.screen.innerHTML = assets.pages[name]
 		this.screen.classList[patternBg ? "add" : "remove"]("pattern-bg")
 	}
-	ajax(url, customRequest){
+	ajax(url, customRequest, customResponse){
 		var request = new XMLHttpRequest()
 		request.open("GET", url)
-		var promise = pageEvents.load(request).then(() => {
-			if(request.status === 200){
-				return request.response
-			}else{
-				return Promise.reject(`${url} (${request.status})`)
-			}
-		})
+		var promise = pageEvents.load(request)
+		if(!customResponse){
+			promise = promise.then(() => {
+				if(request.status === 200){
+					return request.response
+				}else{
+					return Promise.reject(`${url} (${request.status})`)
+				}
+			})
+		}
 		if(customRequest){
 			customRequest(request)
 		}

--- a/public/src/js/loadsong.js
+++ b/public/src/js/loadsong.js
@@ -108,7 +108,9 @@ class LoadSong{
 					return this.scaleImg(img, filename, prefix, force)
 				}), songObj.custom ? filename + ".png" : skinBase + filename + ".png")
 				if(songObj.custom){
-					img.src = URL.createObjectURL(song.songSkin[filename + ".png"])
+					this.addPromise(song.songSkin[filename + ".png"].blob().then(blob => {
+						img.src = URL.createObjectURL(blob)
+					}))
 				}else{
 					img.src = skinBase + filename + ".png"
 				}

--- a/public/src/js/main.js
+++ b/public/src/js/main.js
@@ -89,6 +89,7 @@ var vectors
 var settings
 var scoreStorage
 var account = {}
+var gpicker
 
 pageEvents.add(root, ["touchstart", "touchmove", "touchend"], event => {
 	if(event.cancelable && cancelTouch && event.target.tagName !== "SELECT"){

--- a/public/src/js/songselect.js
+++ b/public/src/js/songselect.js
@@ -586,7 +586,7 @@ class SongSelect{
 				})
 			}
 		}else if(this.state.locked !== 1 || fromP2){
-			if(this.songs[this.selectedSong].courses && (this.state.locked === 0 || fromP2)){
+			if(this.songs[this.selectedSong].courses && !this.songs[this.selectedSong].unloaded && (this.state.locked === 0 || fromP2)){
 				this.state.moveMS = ms
 			}else{
 				this.state.moveMS = ms - this.songSelecting.speed * this.songSelecting.resize
@@ -2222,7 +2222,7 @@ class SongSelect{
 			]
 			this.draw.layeredText({
 				ctx: ctx,
-				text: strings.ok,
+				text: strings.tutorial.ok,
 				x: _x,
 				y: _y + 18,
 				width: _w,

--- a/public/src/js/songselect.js
+++ b/public/src/js/songselect.js
@@ -1090,7 +1090,7 @@ class SongSelect{
 		}
 		
 		if(screen === "song"){
-			if(this.songs[this.selectedSong].courses){
+			if(this.songs[this.selectedSong].courses && !this.songs[this.selectedSong].unloaded){
 				selectedWidth = this.songAsset.selectedWidth
 			}
 			
@@ -1101,11 +1101,11 @@ class SongSelect{
 			var resize2 = changeSpeed - resize
 			var scroll = resize2 - resize - scrollDelay * 2
 			var elapsed = ms - this.state.moveMS
-
+			
 			if(this.state.catJump || (this.state.move && ms > this.state.moveMS + resize2 - scrollDelay)){
 				var isJump = this.state.catJump
 				var previousSelectedSong = this.selectedSong
-
+				
 				if(!isJump){
 					this.playSound("se_ka", 0, this.lastMoveBy)
 					this.selectedSong = this.mod(this.songs.length, this.selectedSong + this.state.move)
@@ -1165,7 +1165,7 @@ class SongSelect{
 				
 				if(this.songs[this.selectedSong].action !== "back"){
 					var cat = this.songs[this.selectedSong].originalCategory
-					this.drawBackground(cat)				
+					this.drawBackground(cat)
 				}
 			}
 			if(this.state.moveMS && ms < this.state.moveMS + changeSpeed){
@@ -1291,7 +1291,7 @@ class SongSelect{
 			highlight = 1
 		}
 		var selectedSkin = this.songSkin.selected
-		if(screen === "title" || screen === "titleFadeIn" || this.state.locked === 3){
+		if(screen === "title" || screen === "titleFadeIn" || this.state.locked === 3 || currentSong.unloaded){
 			selectedSkin = currentSong.skin
 			highlight = 2
 		}else if(songSelMoving){
@@ -2278,7 +2278,7 @@ class SongSelect{
 		}else{
 			this.songSelect.style.backgroundImage = "url('" + assets.image["bg_genre_def"].src + "')"
 			}
-		}	
+		}
 	
 	drawClosedSong(config){
 		var ctx = config.ctx
@@ -2476,20 +2476,18 @@ class SongSelect{
 			currentSong.chart = new CachedFile(data, file)
 			return importSongs[currentSong.type === "tja" ? "addTja" : "addOsu"]({
 				file: currentSong.chart,
-				index: 0
+				index: currentSong.id
 			})
 		}).then(() => {
-			var imported = importSongs.songs[0]
+			var imported = importSongs.songs[currentSong.id]
 			importSongs.clean()
-			imported.id = currentSong.id
-			imported.order = currentSong.order
-			delete imported.song_skin
 			songObj.preview_time = imported.preview
 			var index = assets.songs.findIndex(song => song.id === currentSong.id)
 			if(index !== -1){
 				assets.songs[index] = imported
 			}
 			this.songs[selectedSong] = this.addSong(imported)
+			this.state.moveMS = this.getMS() - this.songSelecting.speed * this.songSelecting.resize
 			if(imported.music && currentId === this.previewId){
 				return snd.previewGain.load(imported.music).then(sound => {
 					imported.sound = sound

--- a/public/src/js/songselect.js
+++ b/public/src/js/songselect.js
@@ -2407,7 +2407,7 @@ class SongSelect{
 						return snd.previewGain.load(currentSong.music)
 					})
 				}else if(currentSong.unloaded){
-					var promise = this.getUnloaded(this.selectedSong, songObj)
+					var promise = this.getUnloaded(this.selectedSong, songObj, currentId)
 				}else if(currentSong.sound){
 					songObj.preview_time = prvTime
 					currentSong.sound.gain = snd.previewGain
@@ -2468,13 +2468,13 @@ class SongSelect{
 			snd.musicGain.fadeOut(0.4)
 		}
 	}
-	getUnloaded(selectedSong, songObj){
+	getUnloaded(selectedSong, songObj, currentId){
 		var currentSong = this.songs[selectedSong]
 		var file = currentSong.chart
 		var importSongs = new ImportSongs(false, assets.otherFiles)
 		return file.read(currentSong.type === "tja" ? "sjis" : "").then(data => {
 			currentSong.chart = new CachedFile(data, file)
-			return importSongs.addTja({
+			return importSongs[currentSong.type === "tja" ? "addTja" : "addOsu"]({
 				file: currentSong.chart,
 				index: 0
 			})
@@ -2485,14 +2485,15 @@ class SongSelect{
 			imported.order = currentSong.order
 			delete imported.song_skin
 			songObj.preview_time = imported.preview
-			if(imported.music){
+			var index = assets.songs.findIndex(song => song.id === currentSong.id)
+			if(index !== -1){
+				assets.songs[index] = imported
+			}
+			this.songs[selectedSong] = this.addSong(imported)
+			if(imported.music && currentId === this.previewId){
 				return snd.previewGain.load(imported.music).then(sound => {
 					imported.sound = sound
-					var index = assets.songs.findIndex(song => song.id === currentSong.id)
-					if(index !== -1){
-						assets.songs[index] = imported
-					}
-					this.songs[selectedSong] = this.addSong(imported)
+					this.songs[selectedSong].sound = sound
 					return sound.copy()
 				})
 			}else{

--- a/public/src/js/soundbuffer.js
+++ b/public/src/js/soundbuffer.js
@@ -5,24 +5,11 @@
 		pageEvents.add(window, ["click", "touchend", "keypress"], this.pageClicked.bind(this))
 		this.gainList = []
 	}
-	load(url, local, gain){
-		if(local){
-			var reader = new FileReader()
-			var loadPromise = pageEvents.load(reader).then(event => {
-				return event.target.result
-			})
-			reader.readAsArrayBuffer(url)
-		}else{
-			var loadPromise = loader.ajax(url, request => {
-				request.responseType = "arraybuffer"
-			})
-		}
-		return loadPromise.then(response => {
+	load(file, gain){
+		return file.arrayBuffer().then(response => {
 			return new Promise((resolve, reject) => {
 				return this.context.decodeAudioData(response, resolve, reject)
-			}).catch(error => {
-				throw [error, url]
-			})
+			}).catch(error => Promise.reject([error, file.url]))
 		}).then(buffer => {
 			return new Sound(gain || {soundBuffer: this}, buffer)
 		})
@@ -90,8 +77,8 @@ class SoundGain{
 		}
 		this.setVolume(1)
 	}
-	load(url, local){
-		return this.soundBuffer.load(url, local, this)
+	load(url){
+		return this.soundBuffer.load(url, this)
 	}
 	convertTime(time, absolute){
 		return this.soundBuffer.convertTime(time, absolute)
@@ -134,7 +121,7 @@ class Sound{
 		this.sources = new Set()
 	}
 	copy(gain){
-		return new Sound(gain, this.buffer)
+		return new Sound(gain || this.gain, this.buffer)
 	}
 	getTime(){
 		return this.soundBuffer.getTime()

--- a/public/src/js/strings.js
+++ b/public/src/js/strings.js
@@ -102,20 +102,6 @@ var translations = {
 		tw: "遊戲設定",
 		ko: "게임 설정"
 	},
-	browse: {
-		ja: "参照する…",
-		en: "Browse…",
-		cn: "浏览…",
-		tw: "開啟檔案…",
-		ko: "찾아보기…"
-	},
-	defaultSongList: {
-		ja: "デフォルト曲リスト",
-		en: "Default Song List",
-		cn: "默认歌曲列表",
-		tw: "默認歌曲列表",
-		ko: "기본 노래 목록"
-	},
 	songOptions: {
 		ja: "演奏オプション",
 		en: "Song Options",
@@ -1071,6 +1057,43 @@ var translations = {
 		cn: "带歌词",
 		tw: "帶歌詞",
 		ko: "가사가있는"
+	},
+	customSongs: {
+		title: {
+			en: "Custom Song List",
+		},
+		default: {
+			ja: "デフォルト曲リスト",
+			en: "Default Song List",
+			cn: "默认歌曲列表",
+			tw: "默認歌曲列表",
+			ko: "기본 노래 목록"
+		},
+		description: {
+			en: [
+				"Pick a folder with Taiko chart files in TJA format to play on a custom song list!"
+			]
+		},
+		localFolder: {
+			en: "Local Folder..."
+		},
+		gdriveFolder: {
+			en: "Google Drive..."
+		}
+	},
+	gpicker: {
+		myDrive: {
+			en: "My Drive"
+		},
+		starred: {
+			en: "Starred"
+		},
+		sharedWithMe: {
+			en: "Shared with me"
+		},
+		authError: {
+			en: "Auth error: %s"
+		}
 	}
 }
 var allStrings = {}

--- a/public/src/js/strings.js
+++ b/public/src/js/strings.js
@@ -1060,7 +1060,11 @@ var translations = {
 	},
 	customSongs: {
 		title: {
+			ja: "カスタム曲リスト",
 			en: "Custom Song List",
+			cn: "自定义歌曲列表",
+			tw: "自定義歌曲列表",
+			ko: "맞춤 노래 목록"
 		},
 		default: {
 			ja: "デフォルト曲リスト",
@@ -1075,21 +1079,61 @@ var translations = {
 			]
 		},
 		localFolder: {
-			en: "Local Folder..."
+			ja: "ローカルフォルダ...",
+			en: "Local Folder...",
+			cn: "本地文件夹...",
+			tw: "本地文件夾...",
+			ko: "로컬 폴더..."
 		},
 		gdriveFolder: {
-			en: "Google Drive..."
+			ja: "Google ドライブ...",
+			en: "Google Drive...",
+			cn: "Google云端硬盘...",
+			tw: "Google雲端硬碟...",
+			ko: "구글 드라이브..."
+		},
+		dropzone: {
+			ja: "ここにファイルをドロップ",
+			en: "Drop files here",
+			cn: "将文件拖至此处",
+			tw: "將文件拖至此處",
+			ko: "파일을 여기에 드롭"
+		},
+		importError: {
+			en: "Import Error"
+		},
+		noSongs: {
+			en: "No Taiko chart files have been found in the provided folder."
 		}
 	},
 	gpicker: {
+		locale: {
+			ja: "ja",
+			en: "en-GB",
+			cn: "zh-CN",
+			tw: "zh-TW",
+			ko: "ko"
+		},
 		myDrive: {
-			en: "My Drive"
+			ja: "マイドライブ",
+			en: "My Drive",
+			cn: "我的云端硬盘",
+			tw: "我的雲端硬碟",
+			ko: "내 드라이브"
 		},
 		starred: {
-			en: "Starred"
+			ja: "スター付き",
+			en: "Starred",
+			cn: "已加星标",
+			tw: "已加星號",
+			ko: "중요 문서함"
 		},
 		sharedWithMe: {
-			en: "Shared with me"
+			ja: "共有アイテム",
+			en: "Shared with me",
+			cn: "与我共享",
+			tw: "與我共用",
+			ko: "공유 문서함"
 		},
 		authError: {
 			en: "Auth error: %s"

--- a/public/src/js/view.js
+++ b/public/src/js/view.js
@@ -308,8 +308,8 @@
 						w: _w, h: _h,
 						radius: 11
 					})
-					ctx.fill()					
-
+					ctx.fill()
+					
 					this.draw.layeredText({
 						ctx: ctx,
 						text: selectedSong.category,

--- a/public/src/js/viewassets.js
+++ b/public/src/js/viewassets.js
@@ -175,7 +175,9 @@ class ViewAssets{
 		})
 	}
 	clean(){
-		this.don.clean()
+		if(this.don){
+			this.don.clean()
+		}
 		delete this.ctx
 		delete this.don
 		delete this.fire

--- a/public/src/views/customsongs.html
+++ b/public/src/views/customsongs.html
@@ -1,0 +1,12 @@
+<div class="view-outer">
+	<div class="view">
+		<div class="view-title stroke-sub"></div>
+		<div class="view-content"></div>
+		<div class="left-buttons">
+			<div id="link-localfolder" class="taibtn stroke-sub link-btn"></div>
+			<div id="link-gdrivefolder" class="taibtn stroke-sub link-btn"></div>
+		</div>
+		<div class="view-end-button taibtn stroke-sub selected"></div>
+	</div>
+	<form><input id="browse" type="file" webkitdirectory multiple></form>
+</div>

--- a/public/src/views/customsongs.html
+++ b/public/src/views/customsongs.html
@@ -1,12 +1,24 @@
 <div class="view-outer">
-	<div class="view">
+	<div class="view drag-bg">
 		<div class="view-title stroke-sub"></div>
 		<div class="view-content"></div>
-		<div class="left-buttons">
+		<div class="center-buttons">
 			<div id="link-localfolder" class="taibtn stroke-sub link-btn"></div>
 			<div id="link-gdrivefolder" class="taibtn stroke-sub link-btn"></div>
 		</div>
 		<div class="view-end-button taibtn stroke-sub selected"></div>
+		<div class="view-outer shadow-outer" id="dropzone">
+			<div class="view">
+				<div class="view-content"></div>
+			</div>
+		</div>
+		<div class="view-outer shadow-outer" id="customsongs-error">
+			<div class="view">
+				<div class="view-title stroke-sub"></div>
+				<div class="view-content"></div>
+				<div class="view-end-button taibtn stroke-sub selected"></div>
+			</div>
+		</div>
 	</div>
 	<form><input id="browse" type="file" webkitdirectory multiple></form>
 </div>

--- a/public/src/views/songselect.html
+++ b/public/src/views/songselect.html
@@ -2,5 +2,4 @@
 	<canvas id="song-sel-canvas"></canvas>
 	<div id="song-sel-selectable" tabindex="1"></div>
 	<div id="touch-full-btn"></div>
-	<form><input id="browse" type="file" webkitdirectory multiple></form>
 </div>


### PR DESCRIPTION
- Adds a new page for importing custom songs, where it is possible to pick a local folder (desktop only) or a Google Drive folder (desktop and Android)
  - This feature is disabled on iOS due to the lack of OGG audio support in the browser
- In order to not get rate limited, a TJA file is parsed for metadata only when the song is clicked in the song selection, rather than all at once at import time
- The instance maintainer will need to provide the API credentials in the config.py file to enable this feature
  - This requires a new project to be created at [console.cloud.google.com](https://console.cloud.google.com)
  - [Drive API](https://console.developers.google.com/apis/api/drive.googleapis.com/overview) will have to be enabled
  - [API and OAuth keys](https://console.cloud.google.com/apis/credentials) should be created
    - API key can be restricted to only have Google Drive and Google Picker APIs
    - OAuth Client ID should have Web Application type and JavaScript origins set
    - Editing the [OAuth consent screen](https://console.cloud.google.com/apis/credentials/consent/edit) to have a name and icon is recommended
      - It is semi-required to submit the consent screen for verification as the permission to download all of the Drive files will be asked.
      - Note that the email of the maintainer is publicly visible on the consent screen
  - The project number can be found in the [IAM & Admin settings page](https://console.developers.google.com/iam-admin/settings)