### PR TITLE
Bug fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -371,12 +371,15 @@ def route_admin_users_post():
     max_level = admin['user_level'] - 1
     
     username = request.form.get('username')
-    level = int(request.form.get('level')) or 0
+    try:
+        level = int(request.form.get('level')) or 0
+    except ValueError:
+        level = 0
     
-    user = db.users.find_one({'username': username})
+    user = db.users.find_one({'username_lower': username.lower()})
     if not user:
         flash('Error: User was not found.')
-    elif admin_name == username:
+    elif admin['username'] == user['username']:
         flash('Error: You cannot modify your own level.')
     else:
         user_level = user['user_level']
@@ -386,7 +389,7 @@ def route_admin_users_post():
             flash('Error: This user has higher level than you.')
         else:
             output = {'user_level': level}
-            db.users.update_one({'username': username}, {'$set': output})
+            db.users.update_one({'username': user['username']}, {'$set': output})
             flash('User updated.')
     
     return render_template('admin_users.html', config=get_config(), max_level=max_level, username=username, level=level)

--- a/public/src/css/view.css
+++ b/public/src/css/view.css
@@ -201,6 +201,20 @@ kbd{
 .setting-name::before{
 	padding-left: 0.3em;
 }
+.setting-name::after{
+	content: "";
+	display: block;
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: 40px;
+	height: 100%;
+	background-image: linear-gradient(90deg, transparent, #f6ead4 90%);
+}
+.view-content:not(:hover) .setting-box.selected .setting-name::after,
+.setting-box:hover .setting-name::after{
+	background-image: linear-gradient(90deg, transparent, #ffb547 90%);
+}
 .setting-value{
 	display: flex;
 	background: #fff;
@@ -403,6 +417,7 @@ kbd{
 }
 .customdon-canvas{
 	width: 13em;
+	cursor: pointer;
 }
 .customdon-div label{
 	display: block;

--- a/public/src/js/abstractfile.js
+++ b/public/src/js/abstractfile.js
@@ -13,7 +13,7 @@ function filePermission(file){
 				if(response === "granted"){
 					return file
 				}else{
-					return Promise.reject(file)
+					return Promise.reject(strings.accessNotGrantedError)
 				}
 			})
 		}

--- a/public/src/js/canvascache.js
+++ b/public/src/js/canvascache.js
@@ -27,8 +27,8 @@ class CanvasCache{
 		this.h = h
 		this.lastW = 0
 		this.lastH = 0
-		this.canvas.width = this.w * this.scale
-		this.canvas.height = this.h * this.scale
+		this.canvas.width = Math.max(1, this.w * this.scale)
+		this.canvas.height = Math.max(1, this.h * this.scale)
 		this.ctx.scale(this.scale, this.scale)
 	}
 	get(config, callback, setOnly){

--- a/public/src/js/canvasdraw.js
+++ b/public/src/js/canvasdraw.js
@@ -157,7 +157,7 @@
 			ctx.fillRect(0, 0, w, h)
 		}
 		if(config.cached){
-			if(this.songFrameCache.w !== config.frameCache.w){
+			if(this.songFrameCache.w !== config.frameCache.w || this.songFrameCache.scale !== config.frameCache.ratio){
 				this.songFrameCache.resize(config.frameCache.w, config.frameCache.h, config.frameCache.ratio)
 			}
 			this.songFrameCache.get({
@@ -1680,8 +1680,8 @@
 		if(amount >= 1){
 			return callback(ctx)
 		}else if(amount >= 0){
-			this.tmpCanvas.width = winW || ctx.canvas.width
-			this.tmpCanvas.height = winH || ctx.canvas.height
+			this.tmpCanvas.width = Math.max(1, winW || ctx.canvas.width)
+			this.tmpCanvas.height = Math.max(1, winH || ctx.canvas.height)
 			callback(this.tmpCtx)
 			ctx.save()
 			ctx.globalAlpha = amount

--- a/public/src/js/canvastest.js
+++ b/public/src/js/canvastest.js
@@ -7,8 +7,8 @@ class CanvasTest{
 		var pixelRatio = window.devicePixelRatio || 1
 		var width = innerWidth * pixelRatio
 		var height = innerHeight * pixelRatio
-		this.canvas.width = width
-		this.canvas.height = height
+		this.canvas.width = Math.max(1, width)
+		this.canvas.height = Math.max(1, height)
 		this.ctx = this.canvas.getContext("2d")
 		this.ctx.scale(pixelRatio, pixelRatio)
 		this.ratio = pixelRatio

--- a/public/src/js/controller.js
+++ b/public/src/js/controller.js
@@ -231,6 +231,9 @@ class Controller{
 		this.view.displayScore(score, notPlayed, bigNote)
 	}
 	songSelection(fadeIn, showWarning){
+		if(this.cleaned){
+			return
+		}
 		if(!fadeIn){
 			this.clean()
 		}
@@ -241,6 +244,9 @@ class Controller{
 		}
 	}
 	restartSong(){
+		if(this.cleaned){
+			return
+		}
 		this.clean()
 		if(this.multiplayer){
 			new LoadSong(this.selectedSong, false, true, this.touchEnabled)
@@ -363,6 +369,7 @@ class Controller{
 		return true
 	}
 	clean(){
+		this.cleaned = true
 		if(this.multiplayer === 1){
 			this.syncWith.clean()
 		}

--- a/public/src/js/game.js
+++ b/public/src/js/game.js
@@ -506,10 +506,10 @@ class Game{
 					p2.send("gameend")
 				}
 				this.musicFadeOut++
-			}else if(this.musicFadeOut === 2 && (ms >= started + 8600 && ms >= musicDuration + 250)){
+			}else if(this.musicFadeOut === 2 && (ms >= Math.max(started + 8600, Math.min(started + 8600 + 5000, musicDuration + 250)))){
 				this.controller.displayResults()
 				this.musicFadeOut++
-			}else if(this.musicFadeOut === 3 && (ms >= started + 9600 && ms >= musicDuration + 1250)){
+			}else if(this.musicFadeOut === 3 && (ms >= Math.max(started + 9600, Math.min(started + 9600 + 5000, musicDuration + 1250)))){
 				this.controller.clean()
 				if(this.controller.scoresheet){
 					this.controller.scoresheet.startRedraw()

--- a/public/src/js/importsongs.js
+++ b/public/src/js/importsongs.js
@@ -111,10 +111,7 @@
 						var plugin = plugins.add(obj.data, obj.name)
 						if(plugin){
 							pluginAmount++
-							plugins.imported.push({
-								name: plugin.name,
-								plugin: plugin
-							})
+							plugin.imported = true
 							startPromises.push(plugin.start())
 						}
 					})

--- a/public/src/js/loadsong.js
+++ b/public/src/js/loadsong.js
@@ -239,8 +239,8 @@ class LoadSong{
 				var canvas = document.createElement("canvas")
 				var w = Math.floor(img.width * scale)
 				var h = Math.floor(img.height * scale)
-				canvas.width = w
-				canvas.height = h
+				canvas.width = Math.max(1, w)
+				canvas.height = Math.max(1, h)
 				var ctx = canvas.getContext("2d")
 				ctx.drawImage(img, 0, 0, w, h)
 				var saveScaled = url => {

--- a/public/src/js/logo.js
+++ b/public/src/js/logo.js
@@ -64,8 +64,8 @@
 		var pixelRatio = window.devicePixelRatio || 1
 		var winW = this.canvas.offsetWidth * pixelRatio
 		var winH = this.canvas.offsetHeight * pixelRatio
-		this.canvas.width = winW
-		this.canvas.height = winH
+		this.canvas.width = Math.max(1, winW)
+		this.canvas.height = Math.max(1, winH)
 		ctx.scale(winW / this.width, winH / this.height)
 		
 		ctx.lineJoin = "round"

--- a/public/src/js/p2.js
+++ b/public/src/js/p2.js
@@ -28,16 +28,18 @@ class P2Connection{
 		}
 	}
 	open(){
-		this.closed = false
-		var wsProtocol = location.protocol == "https:" ? "wss:" : "ws:"
-		this.socket = new WebSocket(wsProtocol + "//" + location.host + "/p2")
-		pageEvents.race(this.socket, "open", "close").then(response => {
-			if(response.type === "open"){
-				return this.openEvent()
-			}
-			return this.closeEvent()
-		})
-		pageEvents.add(this.socket, "message", this.messageEvent.bind(this))
+		if(this.closed && !this.disabled){
+			this.closed = false
+			var wsProtocol = location.protocol == "https:" ? "wss:" : "ws:"
+			this.socket = new WebSocket(wsProtocol + "//" + location.host + "/p2")
+			pageEvents.race(this.socket, "open", "close").then(response => {
+				if(response.type === "open"){
+					return this.openEvent()
+				}
+				return this.closeEvent()
+			})
+			pageEvents.add(this.socket, "message", this.messageEvent.bind(this))
+		}
 	}
 	openEvent(){
 		var addedType = this.allEvents.get("open")
@@ -46,8 +48,12 @@ class P2Connection{
 		}
 	}
 	close(){
-		this.closed = true
-		this.socket.close()
+		if(!this.closed){
+			this.closed = true
+			if(this.socket){
+				this.socket.close()
+			}
+		}
 	}
 	closeEvent(){
 		this.removeEventListener(onmessage)
@@ -249,5 +255,13 @@ class P2Connection{
 		}else if(mekadon.miss(circle)){
 			this.notes.shift()
 		}
+	}
+	enable(){
+		this.disabled = false
+		this.open()
+	}
+	disable(){
+		this.disabled = true
+		this.close()
 	}
 }

--- a/public/src/js/scoresheet.js
+++ b/public/src/js/scoresheet.js
@@ -215,8 +215,8 @@ class Scoresheet{
 		
 		if(this.redrawing){
 			if(this.winW !== winW || this.winH !== winH){
-				this.canvas.width = winW
-				this.canvas.height = winH
+				this.canvas.width = Math.max(1, winW)
+				this.canvas.height = Math.max(1, winH)
 				ctx.scale(ratio, ratio)
 				this.canvas.style.width = (winW / this.pixelRatio) + "px"
 				this.canvas.style.height = (winH / this.pixelRatio) + "px"

--- a/public/src/js/songselect.js
+++ b/public/src/js/songselect.js
@@ -104,18 +104,20 @@ class SongSelect{
 				return a.id > b.id ? 1 : -1
 			}
 		})
-		this.songs.push({
-			title: strings.back,
-			skin: this.songSkin.back,
-			action: "back"
-		})
-		this.songs.push({
-			title: strings.randomSong,
-			skin: this.songSkin.random,
-			action: "random",
-			category: strings.random,
-			canJump: true
-		})
+		if(assets.songs.length){
+			this.songs.push({
+				title: strings.back,
+				skin: this.songSkin.back,
+				action: "back"
+			})
+			this.songs.push({
+				title: strings.randomSong,
+				skin: this.songSkin.random,
+				action: "random",
+				category: strings.random,
+				canJump: true
+			})
+		}
 		if(touchEnabled){
 			if(fromTutorial === "tutorial"){
 				fromTutorial = false
@@ -287,7 +289,8 @@ class SongSelect{
 			options: 0,
 			selLock: false,
 			catJump: false,
-			focused: true
+			focused: true,
+			waitPreview: 0
 		}
 		this.songSelecting = {
 			speed: 400,
@@ -472,7 +475,7 @@ class SongSelect{
 				this.toAccount()
 			}else if(p2.session && 438 < mouse.x && mouse.x < 834 && mouse.y > 603){
 				this.toSession()
-			}else if(!p2.session && mouse.x > 641 && mouse.y > 603 && p2.socket.readyState === 1 && !assets.customSongs){
+			}else if(!p2.session && mouse.x > 641 && mouse.y > 603 && p2.socket && p2.socket.readyState === 1 && !assets.customSongs){
 				this.toSession()
 			}else{
 				var moveBy = this.songSelMouse(mouse.x, mouse.y)
@@ -508,7 +511,7 @@ class SongSelect{
 		event.preventDefault()
 	}
 	mouseWheel(event){
-		if(this.state.screen === "song"){
+		if(this.state.screen === "song" && this.state.focused){
 			this.wheelTimer = this.getMS()
 
 			if(event.deltaY < 0) {
@@ -809,7 +812,7 @@ class SongSelect{
 			this.selectedDiff = 1
 			do{
 				this.state.options = this.mod(this.optionsList.length, this.state.options + moveBy)
-			}while((p2.socket.readyState !== 1 || assets.customSongs) && this.state.options === 2)
+			}while((p2.socket && p2.socket.readyState !== 1 || assets.customSongs) && this.state.options === 2)
 		}
 	}
 	toTitleScreen(){
@@ -913,12 +916,7 @@ class SongSelect{
 				}
 			}
 		}
-
-		if(this.wheelScrolls !== 0 && !this.state.locked && ms >= this.wheelTimer + 20) {
-			this.moveToSong(this.wheelScrolls)
-			this.wheelScrolls -= this.wheelScrolls
-		}
-
+		
 		if(!this.redrawRunning){
 			return
 		}
@@ -944,8 +942,8 @@ class SongSelect{
 		var ratioY = winH / 720
 		var ratio = (ratioX < ratioY ? ratioX : ratioY)
 		if(this.winW !== winW || this.winH !== winH){
-			this.canvas.width = winW
-			this.canvas.height = winH
+			this.canvas.width = Math.max(1, winW)
+			this.canvas.height = Math.max(1, winH)
 			ctx.scale(ratio, ratio)
 			this.canvas.style.width = (winW / this.pixelRatio) + "px"
 			this.canvas.style.height = (winH / this.pixelRatio) + "px"
@@ -1033,6 +1031,13 @@ class SongSelect{
 		var songSelMoving = false
 		var screen = this.state.screen
 		var selectedWidth = this.songAsset.width
+		
+		if(this.wheelScrolls !== 0 && !this.state.locked && ms >= this.wheelTimer + 20) {
+			this.state.move = this.wheelScrolls
+			this.state.waitPreview = ms + 400
+			this.wheelScrolls = 0
+			this.endPreview()
+		}
 		
 		if(screen === "title" || screen === "titleFadeIn"){
 			if(ms > this.state.screenMS + 1000){
@@ -2439,7 +2444,7 @@ class SongSelect{
 	}
 	
 	startPreview(loadOnly){
-		if(!loadOnly && this.state && this.state.showWarning){
+		if(!loadOnly && this.state && this.state.showWarning || this.state.waitPreview > this.getMS()){
 			return
 		}
 		var currentSong = this.songs[this.selectedSong]

--- a/public/src/js/songselect.js
+++ b/public/src/js/songselect.js
@@ -1033,10 +1033,14 @@ class SongSelect{
 		var selectedWidth = this.songAsset.width
 		
 		if(this.wheelScrolls !== 0 && !this.state.locked && ms >= this.wheelTimer + 20) {
-			this.state.move = this.wheelScrolls
-			this.state.waitPreview = ms + 400
+			if(p2.session){
+				this.moveToSong(this.wheelScrolls)
+			}else{
+				this.state.move = this.wheelScrolls
+				this.state.waitPreview = ms + 400
+				this.endPreview()
+			}
 			this.wheelScrolls = 0
-			this.endPreview()
 		}
 		
 		if(screen === "title" || screen === "titleFadeIn"){

--- a/public/src/js/soundbuffer.js
+++ b/public/src/js/soundbuffer.js
@@ -73,7 +73,10 @@
 	}
 }
 class SoundGain{
-	constructor(soundBuffer, channel){
+	constructor(...args){
+		this.init(...args)
+	}
+	init(soundBuffer, channel){
 		this.soundBuffer = soundBuffer
 		this.gainNode = soundBuffer.context.createGain()
 		if(channel){
@@ -121,7 +124,10 @@ class SoundGain{
 	}
 }
 class Sound{
-	constructor(gain, buffer){
+	constructor(...args){
+		this.init(...args)
+	}
+	init(gain, buffer){
 		this.gain = gain
 		this.buffer = buffer
 		this.soundBuffer = gain.soundBuffer

--- a/public/src/js/strings.js
+++ b/public/src/js/strings.js
@@ -216,6 +216,10 @@ var translations = {
 		ja: "曲「%s」を読み込むことができませんでした。（ID：%s）\n\n%s",
 		en: "Could not load song %s with ID %s.\n\n%s"
 	},
+	accessNotGrantedError: {
+		ja: null,
+		en: "Permission to access the file was not granted"
+	},
 	loading: {
 		ja: "ロード中...",
 		en: "Loading...",

--- a/public/src/js/tutorial.js
+++ b/public/src/js/tutorial.js
@@ -12,28 +12,84 @@ class Tutorial{
 		this.tutorialTitle = this.getElement("view-title")
 		this.tutorialDiv = document.createElement("div")
 		this.getElement("view-content").appendChild(this.tutorialDiv)
+		
+		this.items = []
+		this.items.push(this.endButton)
+		this.selected = this.items.length - 1
+		
 		this.setStrings()
 		
-		pageEvents.add(this.endButton, ["mousedown", "touchstart"], event => {
-			if(event.type === "touchstart"){
-				event.preventDefault()
-				this.touched = true
-			}else if(event.type === "mousedown" && event.which !== 1){
-				return
-			}
-			this.onEnd(true)
-		})
+		pageEvents.add(this.endButton, ["mousedown", "touchstart"], this.onEnd.bind(this))
+		pageEvents.add(this.formButton, ["mousedown", "touchstart"], this.linkButton.bind(this))
 		this.keyboard = new Keyboard({
-			confirm: ["enter", "space", "esc", "don_l", "don_r"]
-		}, this.onEnd.bind(this))
+			confirm: ["enter", "space", "don_l", "don_r"],
+			previous: ["left", "up", "ka_l"],
+			next: ["right", "down", "ka_r"],
+			back: ["escape"]
+		}, this.keyPressed.bind(this))
 		this.gamepad = new Gamepad({
-			confirm: ["start", "b", "ls", "rs"]
-		}, this.onEnd.bind(this))
+			"confirm": ["b", "ls", "rs"],
+			"previous": ["u", "l", "lb", "lt", "lsu", "lsl"],
+			"next": ["d", "r", "rb", "rt", "lsd", "lsr"],
+			"back": ["start", "a"]
+		}, this.keyPressed.bind(this))
 		
 		pageEvents.send("tutorial")
 	}
 	getElement(name){
 		return loader.screen.getElementsByClassName(name)[0]
+	}
+	keyPressed(pressed, name){
+		if(!pressed){
+			return
+		}
+		var selected = this.items[this.selected]
+		if(name === "confirm"){
+			if(selected === this.endButton){
+				this.onEnd()
+			}else{
+				this.getLink(selected).click()
+				assets.sounds["se_don"].play()
+			}
+		}else if(name === "previous" || name === "next"){
+			selected.classList.remove("selected")
+			this.selected = this.mod(this.items.length, this.selected + (name === "next" ? 1 : -1))
+			this.items[this.selected].classList.add("selected")
+			assets.sounds["se_ka"].play()
+		}else if(name === "back"){
+			this.onEnd()
+		}
+	}
+	mod(length, index){
+		return ((index % length) + length) % length
+	}
+	onEnd(event){
+		var touched = false
+		if(event){
+			if(event.type === "touchstart"){
+				event.preventDefault()
+				touched = true
+			}else if(event.which !== 1){
+				return
+			}
+		}
+		this.clean()
+		assets.sounds["se_don"].play()
+		try{
+			localStorage.setItem("tutorial", "true")
+		}catch(e){}
+		setTimeout(() => {
+			new SongSelect(this.fromSongSel ? "tutorial" : false, false, touched, this.songId)
+		}, 500)
+	}
+	getLink(target){
+		return target.getElementsByTagName("a")[0]
+	}
+	linkButton(event){
+		if(event.target === event.currentTarget && (event.type === "touchstart" || event.which === 1)){
+			this.getLink(event.currentTarget).click()
+			assets.sounds["se_don"].play()
+		}
 	}
 	insertText(text, parent){
 		parent.appendChild(document.createTextNode(text))

--- a/public/src/js/tutorial.js
+++ b/public/src/js/tutorial.js
@@ -20,7 +20,6 @@ class Tutorial{
 		this.setStrings()
 		
 		pageEvents.add(this.endButton, ["mousedown", "touchstart"], this.onEnd.bind(this))
-		pageEvents.add(this.formButton, ["mousedown", "touchstart"], this.linkButton.bind(this))
 		this.keyboard = new Keyboard({
 			confirm: ["enter", "space", "don_l", "don_r"],
 			previous: ["left", "up", "ka_l"],
@@ -52,10 +51,12 @@ class Tutorial{
 				assets.sounds["se_don"].play()
 			}
 		}else if(name === "previous" || name === "next"){
-			selected.classList.remove("selected")
-			this.selected = this.mod(this.items.length, this.selected + (name === "next" ? 1 : -1))
-			this.items[this.selected].classList.add("selected")
-			assets.sounds["se_ka"].play()
+			if(this.items.length >= 2){
+				selected.classList.remove("selected")
+				this.selected = this.mod(this.items.length, this.selected + (name === "next" ? 1 : -1))
+				this.items[this.selected].classList.add("selected")
+				assets.sounds["se_ka"].play()
+			}
 		}else if(name === "back"){
 			this.onEnd()
 		}
@@ -117,18 +118,6 @@ class Tutorial{
 			var kbd = document.createElement("kbd")
 			kbd.innerText = key[i]
 			parent.appendChild(kbd)
-		}
-	}
-	onEnd(pressed, name){
-		if(pressed){
-			this.clean()
-			assets.sounds["se_don"].play()
-			try{
-				localStorage.setItem("tutorial", "true")
-			}catch(e){}
-			setTimeout(() => {
-				new SongSelect(this.fromSongSel ? "tutorial" : false, false, this.touched, this.songId)
-			}, 500)
 		}
 	}
 	setStrings(){

--- a/public/src/js/view.js
+++ b/public/src/js/view.js
@@ -199,8 +199,8 @@
 			this.ratio = ratio
 			
 			if(this.player !== 2){
-				this.canvas.width = winW
-				this.canvas.height = winH
+				this.canvas.width = Math.max(1, winW)
+				this.canvas.height = Math.max(1, winH)
 				ctx.scale(ratio, ratio)
 				this.canvas.style.width = (winW / this.pixelRatio) + "px"
 				this.canvas.style.height = (winH / this.pixelRatio) + "px"
@@ -1515,6 +1515,7 @@
 	}
 	updateNoteFaces(){
 		var ms = this.getMS()
+		var lastNextBeat = this.nextBeat
 		while(ms >= this.nextBeat){
 			this.nextBeat += this.beatInterval
 			if(this.controller.getCombo() >= 50){
@@ -1528,6 +1529,9 @@
 					small: 0,
 					big: 3
 				}
+			}
+			if(this.nextBeat <= lastNextBeat){
+				break
 			}
 		}
 	}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,8 @@
 	<link rel="icon" href="{{config.assets_baseurl}}img/favicon.png" type="image/png">
 	<meta name="viewport" content="width=device-width, user-scalable=no">
 	<meta name="description" content="パソコンとスマホのブラウザ向けの太鼓の達人シミュレータ 🥁 Taiko no Tatsujin rhythm game simulator for desktop and mobile browsers">
+	<meta name="keywords" content="taiko no tatsujin, taiko, don chan, online, rhythm, browser, html5, game, for browsers, pc, arcade, emulator, free, download, website, 太鼓の達人, 太鼓ウェブ, 太鼓之達人, 太鼓達人, 太鼓网页, 网页版, 太鼓網頁, 網頁版, 태고의 달인, 태고 웹">
+	<meta name="color-scheme" content="only light">
 
 	<link rel="stylesheet" href="/src/css/loader.css?{{version.commit_short}}">
 
@@ -18,14 +20,20 @@
 <body>
 	<div id="assets"></div>
 	<div id="screen" class="pattern-bg"></div>
-	<div id="version">
+	<div data-nosnippet id="version">
 		{% if version.version and version.commit_short and version.commit %}
 			<a href="{{version.url}}commit/{{version.commit}}" target="_blank" id="version-link" class="stroke-sub" alt="taiko-web ver.{{version.version}} ({{version.commit_short}})">taiko-web ver.{{version.version}} ({{version.commit_short}})</a>
 		{% else %}
-			<a href="{{version.url}}" target="_blank" id="version-link" class="stroke-sub" alt="taiko-web (unknown version)">taiko-web (unknown version)</a>
+			<a href="{{version.url}}" target="_blank" rel="noopener" id="version-link" class="stroke-sub" alt="taiko-web (unknown version)">taiko-web (unknown version)</a>
 		{% endif %}
 	</div>
 	<script src="/src/js/browsersupport.js?{{version.commit_short}}"></script>
 	<script src="/src/js/main.js?{{version.commit_short}}"></script>
+	<noscript>
+		<div data-nosnippet id="unsupportedBrowser">
+			<div id="unsupportedWarn">!</div>
+			<span>Taiko Web requires JavaScript to be enabled in the browser</span>
+		</div>
+	</noscript>
 </body>
 </html>


### PR DESCRIPTION
- Change song select mouse wheel song scrolling to be instant
- Clicking on don chan in account settings toggles the animation
- If the music is too long for the chart, the results screen is shown earlier
- Fix weird BPM values freezing the browser (zero, negative, and very large)
- Add a warning to the page when JavaScript is disabled in the browser
- Fix Chrome auto dark mode by forcing light mode on the page
- Add a meta keywords tag to the page
- Fix plugin names getting cut off in the menu
- Delay the function editing of the EditFunction class in plugins to the start() function instead of load()
  - When stopping one of the plugins, all the plugins have to be stopped in reverse order and started again so that patched code of a stopped plugin does not linger around
- Fix importing plugins that have a SyntaxError
- Fix plugins getting the same internal name when added without one, causing them to not appear in the plugin settings
- Support editing args in EditFunction for plugins
- Prevent multiple websockets from being opened
- Fix page freezing after selecting Random song with no songs
- Fix the back button being repeated twice when there are no songs
- Fix /admin/users not accepting case insensitive usernames
- Pressing enter on the Delete Account field does the expected action instead of refreshing the page
- Better error message when custom folder access is denied
- Fix being able to start netplay in custom songs after refreshing the page (#383)
- Fix an error when importing songs from previous session and clicking on the white spot where you normally start multiplayer session
- Fix canvas elements becoming smaller than 1x1 resolution and crashing the game (#390)
- Fix song frame shadow cache on song select not being cleared when resizing the browser window, causing it to become blurry
- Fix a pause-restart error when you hit both confirm keys on the restart button