### PR TITLE
Misc fixes

### DIFF
--- a/public/src/css/search.css
+++ b/public/src/css/search.css
@@ -48,7 +48,7 @@
 	padding: 0.5em 0.7em;
 	border-radius: 0.2em;
 	border: 0.13em black solid;
-	font-family: TnT;
+	font-family: inherit;
 	box-sizing: border-box;
 	-webkit-box-sizing:border-box;
 	-moz-box-sizing: border-box;

--- a/public/src/js/about.js
+++ b/public/src/js/about.js
@@ -160,6 +160,10 @@
 		diag.push("Language: " + strings.id + userLangStr)
 		var latency = settings.getItem("latency")
 		diag.push("Audio Latency: " + (latency.audio > 0 ? "+" : "") + latency.audio.toString() + "ms, Video Latency: " + (latency.video > 0 ? "+" : "") + latency.video.toString() + "ms")
+		var pluginList = plugins.allPlugins.map(pluginLoader => {
+			return (pluginLoader.plugin.module && pluginLoader.plugin.module.name || pluginLoader.name) + (pluginLoader.plugin.started ? " (started)" : "")
+		})
+		diag.push("Plugins: " + pluginList.join(", "))
 		var errorObj = {}
 		if(localStorage["lastError"]){
 			try{

--- a/public/src/js/canvasdraw.js
+++ b/public/src/js/canvasdraw.js
@@ -299,7 +299,7 @@
 	
 	verticalText(config){
 		var ctx = config.ctx
-		var inputText = config.text.toString()
+		var inputText = "" + config.text
 		var mul = config.fontSize / 40
 		var ura = false
 		var r = this.regex
@@ -623,7 +623,7 @@
 	
 	layeredText(config, layers){
 		var ctx = config.ctx
-		var inputText = config.text.toString()
+		var inputText = "" + config.text
 		var mul = config.fontSize / 40
 		var ura = false
 		var r = this.regex

--- a/public/src/js/loader.js
+++ b/public/src/js/loader.js
@@ -327,7 +327,9 @@ class Loader{
 					p2.hash("")
 				}
 				
-				promises.push(this.canvasTest.drawAllImages())
+				promises.push(this.canvasTest.drawAllImages().then(result => {
+					perf.allImg = result
+				}))
 				
 				if(gameConfig.plugins){
 					gameConfig.plugins.forEach(obj => {
@@ -349,8 +351,7 @@ class Loader{
 					})
 				}
 				
-				Promise.all(promises).then(result => {
-					perf.allImg = result
+				Promise.all(promises).then(() => {
 					perf.load = Date.now() - this.startTime
 					this.canvasTest.clean()
 					this.clean()

--- a/public/src/js/lyrics.js
+++ b/public/src/js/lyrics.js
@@ -77,7 +77,7 @@ class Lyrics{
 								break
 							}
 							var lang = text.slice(index1 + 6, index2).toLowerCase()
-							if(strings.id === lang){
+							if(strings.preferEn && lang === "en" || strings.id === lang){
 								var index3 = text.indexOf("<lang ", index2 + 1)
 								if(index3 !== -1){
 									textLang = text.slice(index2 + 1, index3)

--- a/public/src/js/plugins.js
+++ b/public/src/js/plugins.js
@@ -20,6 +20,10 @@ class Plugins{
 		var name = options.name
 		if(!name && isUrl){
 			name = script
+			var index = name.lastIndexOf("?")
+			if(index !== -1){
+				name = name.slice(0, index)
+			}
 			var index = name.lastIndexOf("/")
 			if(index !== -1){
 				name = name.slice(index + 1)
@@ -50,14 +54,16 @@ class Plugins{
 		return plugin
 	}
 	remove(name){
-		var hash = this.pluginMap[name].hash
-		if(hash){
-			var index = this.hashes.indexOf(hash)
-			if(index !== -1){
-				this.hashes.splice(index, 1)
+		if(name in this.pluginMap){
+			var hash = this.pluginMap[name].hash
+			if(hash){
+				var index = this.hashes.indexOf(hash)
+				if(index !== -1){
+					this.hashes.splice(index, 1)
+				}
 			}
+			this.unload(name)
 		}
-		this.unload(name)
 		var index = this.allPlugins.findIndex(obj => obj.name === name)
 		if(index !== -1){
 			this.allPlugins.splice(index, 1)
@@ -235,10 +241,12 @@ class Plugins{
 					default: true,
 					getItem: () => plugin.started,
 					setItem: value => {
-						if(plugin.started && !value){
-							this.stop(plugin.name)
-						}else if(!plugin.started && value){
-							this.start(plugin.name)
+						if(plugin.name in this.pluginMap){
+							if(plugin.started && !value){
+								this.stop(plugin.name)
+							}else if(!plugin.started && value){
+								this.start(plugin.name)
+							}
 						}
 					}
 				})
@@ -321,9 +329,15 @@ class PluginLoader{
 				try{
 					this.module = new module.default()
 				}catch(e){
-					console.error(e)
 					this.error()
-					return
+					var error = new Error()
+					error.stack = "Error initializing plugin: " + this.name + "\n" + e.stack
+					if(loadErrors){
+						return Promise.reject(error)
+					}else{
+						console.error(error)
+						return Promise.resolve()
+					}
 				}
 				var output
 				try{
@@ -334,22 +348,41 @@ class PluginLoader{
 						output = this.module.load(this)
 					}
 				}catch(e){
-					console.error(e)
 					this.error()
+					var error = new Error()
+					error.stack = "Error in plugin load: " + this.name + "\n" + e.stack
+					if(loadErrors){
+						return Promise.reject(error)
+					}else{
+						console.error(error)
+						return Promise.resolve()
+					}
 				}
 				if(typeof output === "object" && output.constructor === Promise){
 					return output.catch(e => {
-						console.error(e)
 						this.error()
-						return Promise.resolve()
+						var error = new Error()
+						error.stack = "Error in plugin load promise: " + this.name + (e ? "\n" + e.stack : "")
+						if(loadErrors){
+							return Promise.reject(error)
+						}else{
+							console.error(error)
+							return Promise.resolve()
+						}
 					})
 				}
 			}, e => {
-				console.error(e)
 				this.error()
-				if(loadErrors){
-					return Promise.reject(e)
+				if(e.name === "SyntaxError"){
+					var error = new SyntaxError()
+					error.stack = "Error in plugin syntax: " + this.name + "\n" + e.stack
 				}else{
+					var error = e
+				}
+				if(loadErrors){
+					return Promise.reject(error)
+				}else{
+					console.error(error)
 					return Promise.resolve()
 				}
 			})
@@ -370,13 +403,15 @@ class PluginLoader{
 						this.module.start()
 					}
 				}catch(e){
-					console.error(e)
+					var error = new Error()
+					error.stack = "Error in plugin start: " + this.name + "\n" + e.stack
+					console.error(error)
 					this.error()
 				}
 			}
 		})
 	}
-	stop(orderChange, error){
+	stop(orderChange, noError){
 		if(this.loaded && this.started){
 			if(!orderChange){
 				var stopIndex = plugins.startOrder.indexOf(this.name)
@@ -397,8 +432,10 @@ class PluginLoader{
 					this.module.stop()
 				}
 			}catch(e){
-				console.error(e)
-				if(!error){
+				var error = new Error()
+				error.stack = "Error in plugin stop: " + this.name + "\n" + e.stack
+				console.error(error)
+				if(!noError){
 					this.error()
 				}
 			}
@@ -426,7 +463,9 @@ class PluginLoader{
 						this.module.unload()
 					}
 				}catch(e){
-					console.error(e)
+					var error = new Error()
+					error.stack = "Error in plugin unload: " + this.name + "\n" + e.stack
+					console.error(error)
 				}
 				delete this.module
 			}
@@ -437,7 +476,9 @@ class PluginLoader{
 			try{
 				this.module.error()
 			}catch(e){
-				console.error(e)
+				var error = new Error()
+				error.stack = "Error in plugin error: " + this.name + "\n" + e.stack
+				console.error(error)
 			}
 		}
 		this.unload(true)
@@ -481,9 +522,17 @@ class EditValue{
 		if(this.name){
 			this.original = this.name[0][this.name[1]]
 		}
-		var output = this.loadCallback(this.original)
+		try{
+			var output = this.loadCallback(this.original)
+		}catch(e){
+			console.error(this.loadCallback)
+			var error = new Error()
+			error.stack = "Error editing the value of " + this.getName() + "\n" + e.stack
+			throw error
+		}
 		if(typeof output === "undefined"){
-			throw new Error("A value is expected to be returned")
+			console.error(this.loadCallback)
+			throw new Error("Error editing the value of " + this.getName() + ": A value is expected to be returned")
 		}
 		if(this.name){
 			this.name[0][this.name[1]] = output
@@ -500,6 +549,27 @@ class EditValue{
 		}
 		return this.original
 	}
+	getName(){
+		var name = "unknown"
+		try{
+			if(this.name){
+				var name = (
+					typeof this.name[0] === "function" && this.name[0].name
+					|| (
+						typeof this.name[0] === "object" && typeof this.name[0].constructor === "function" && (
+							this.name[0] instanceof this.name[0].constructor ? (() => {
+								var consName = this.name[0].constructor.name || ""
+								return consName.slice(0, 1).toLowerCase() + consName.slice(1)
+							})() : this.name[0].constructor.name + ".prototype"
+						)
+					) || name
+				) + (this.name[1] ? "." + this.name[1] : "")
+			}
+		}catch(e){
+			name = "error"
+		}
+		return name
+	}
 	unload(){
 		delete this.name
 		delete this.original
@@ -513,11 +583,33 @@ class EditFunction extends EditValue{
 			this.original = this.name[0][this.name[1]]
 		}
 		var args = plugins.argsFromFunc(this.original)
-		var output = this.loadCallback(plugins.strFromFunc(this.original), args)
-		if(typeof output === "undefined"){
-			throw new Error("A value is expected to be returned")
+		try{
+			var output = this.loadCallback(plugins.strFromFunc(this.original), args)
+		}catch(e){
+			console.error(this.loadCallback)
+			var error = new Error()
+			error.stack = "Error editing the function value of " + this.getName() + "\n" + e.stack
+			throw error
 		}
-		var output = Function(...args, output)
+		if(typeof output === "undefined"){
+			console.error(this.loadCallback)
+			throw new Error("Error editing the function value of " + this.getName() + ": A value is expected to be returned")
+		}
+		try{
+			var output = Function(...args, output)
+		}catch(e){
+			console.error(this.loadCallback)
+			var error = new SyntaxError()
+			var blob = new Blob([output], {
+				type: "application/javascript"
+			})
+			var url = URL.createObjectURL(blob)
+			error.stack = "Error editing the function value of " + this.getName() + ": Could not evaluate string, check the full string for errors: " + url + "\n" + e.stack
+			setTimeout(() => {
+				URL.revokeObjectURL(url)
+			}, 5 * 60 * 1000)
+			throw error
+		}
 		if(this.name){
 			this.name[0][this.name[1]] = output
 		}

--- a/public/src/js/scorestorage.js
+++ b/public/src/js/scorestorage.js
@@ -48,7 +48,7 @@ class ScoreStorage{
 						var scoreArray = diffArray[i].slice(1).split(",")
 						for(var j in this.scoreKeys){
 							var name = this.scoreKeys[j]
-							var value = parseInt(scoreArray[j], 36) || 0
+							var value = parseInt(scoreArray[j] || 0, 36) || 0
 							if(value < 0){
 								value = 0
 							}


### PR DESCRIPTION
- Add Patch.addLanguage for language plugins
- Song select fixes 
  - Searching diverge:yes returns songs with branches
  - Fade out music slightly while search window is open
  - When opening search box with a saved query, all the text gets selected
  - Fix Ctrl+F not working during song select fade in
  - Fix edge case highlighting only working on lowercase letters
  - Fix right clicking selected text in the search box so it no longer gets unselected
  - Fix Netplay option appearing when netplay is offline
  - Use category id instead of name in the generated stylesheet
  - Languages can choose to fallback to english instead of japanese with preferEn
- Easier plugin debugging 
  - Make debugging syntax errors in plugins easier by catching the errors and printing relevant information
  - Fix default plugin rejected load promise resolving unexpectedly
  - Fix default plugin id not stripping the search part of the url
- More fixes
  - Add list of enabled plugins to the diagnostics
  - Fix broken image permormance in the diagnostics
  - Fix parsing undefined values in score storage
  - Do not error when verticalText or layeredText gets undefined text