### PR TITLE
Lyrics, search, and other fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,3 @@
-﻿###### 下記の問題を説明してください。 スクリーンショットと診断情報を含めてください。
-###### Describe the problem you are having below. Please include a screenshot and the diagnostic information.
+﻿<!--下記の問題を説明してください。 スクリーンショットと診断情報を含めてください。-->
+<!--Describe the problem you are having below. Please include a screenshot and the diagnostic information.-->
 

--- a/public/src/js/browsersupport.js
+++ b/public/src/js/browsersupport.js
@@ -14,6 +14,10 @@ function browserSupport(){
 			eval("class a{}")
 			return true
 		},
+		"Class field declarations": function(){
+			eval("class a{a=1}")
+			return true
+		},
 		"Array.find": function(){
 			return "find" in Array.prototype && "findIndex" in Array.prototype
 		},

--- a/public/src/js/canvasdraw.js
+++ b/public/src/js/canvasdraw.js
@@ -462,8 +462,8 @@
 			config.selectable.innerHTML = ""
 			var scale = config.selectableScale
 			var style = config.selectable.style
-			style.left = (config.x - config.width / 2) * scale + "px"
-			style.top = config.y * scale + "px"
+			style.left = ((config.x - config.width / 2) * scale + (config.selectableX || 0)) + "px"
+			style.top = (config.y * scale + (config.selectableY || 0)) + "px"
 			style.width = config.width * scale + "px"
 			style.height = (drawnHeight+15) * scale + "px"
 			style.fontSize = 40 * mul * scale + "px"

--- a/public/src/js/customsongs.js
+++ b/public/src/js/customsongs.js
@@ -89,6 +89,11 @@ class CustomSongs{
 			var dropContent = this.dropzone.getElementsByClassName("view-content")[0]
 			dropContent.innerText = strings.customSongs.dropzone
 			this.dragging = false
+			this.dragTarget = null
+			pageEvents.add(document, "dragenter", event => {
+				event.preventDefault()
+				this.dragTarget = event.target
+			})
 			pageEvents.add(document, "dragover", event => {
 				event.preventDefault()
 				if(!this.locked){
@@ -100,8 +105,11 @@ class CustomSongs{
 				}
 			})
 			pageEvents.add(document, "dragleave", () => {
-				this.dropzone.classList.remove("dragover")
-				this.dragging = false
+				if(this.dragTarget === event.target){
+					event.preventDefault()
+					this.dropzone.classList.remove("dragover")
+					this.dragging = false
+				}
 			})
 			pageEvents.add(document, "drop", this.filesDropped.bind(this))
 		}
@@ -522,8 +530,9 @@ class CustomSongs{
 		pageEvents.remove(this.errorDiv, ["mousedown", "touchstart"])
 		pageEvents.remove(this.errorEnd, ["mousedown", "touchstart"])
 		if(DataTransferItem.prototype.webkitGetAsEntry){
-			pageEvents.remove(document, ["dragover", "dragleave", "drop"])
+			pageEvents.remove(document, ["dragenter", "dragover", "dragleave", "drop"])
 			delete this.dropzone
+			delete this.dragTarget
 		}
 		if(gpicker){
 			gpicker.tokenResolve = null

--- a/public/src/js/game.js
+++ b/public/src/js/game.js
@@ -172,36 +172,47 @@ class Game{
 				var measure = measures[i]
 				if(measure.ms > ms){
 					break
-				}else if(measure.nextBranch && !measure.gameChecked){
-					measure.gameChecked = true
-					var branch = measure.nextBranch
-					if(branch.type){
-						var accuracy = 0
-						if(branch.type === "drumroll"){
-							if(force.branch){
-								var accuracy = Math.max(0, branch.requirement[force.branch])
-							}else{
-								var accuracy = this.sectionDrumroll
+				}else{
+					if(measure.nextBranch && !measure.gameChecked){
+						measure.gameChecked = true
+						var branch = measure.nextBranch
+						if(branch.type){
+							var accuracy = 0
+							if(branch.type === "drumroll"){
+								if(force.branch){
+									var accuracy = Math.max(0, branch.requirement[force.branch])
+								}else{
+									var accuracy = this.sectionDrumroll
+								}
+							}else if(this.sectionNotes.length !== 0){
+								if(force.branch){
+									var accuracy = Math.max(0, Math.min(100, branch.requirement[force.branch]))
+								}else{
+									var accuracy = this.sectionNotes.reduce((a, b) => a + b) / this.sectionNotes.length * 100
+								}
 							}
-						}else if(this.sectionNotes.length !== 0){
-							if(force.branch){
-								var accuracy = Math.max(0, Math.min(100, branch.requirement[force.branch]))
+							if(accuracy >= branch.requirement.master){
+								this.setBranch(branch, "master")
+							}else if(accuracy >= branch.requirement.advanced){
+								this.setBranch(branch, "advanced")
 							}else{
-								var accuracy = this.sectionNotes.reduce((a, b) => a + b) / this.sectionNotes.length * 100
+								this.setBranch(branch, "normal")
 							}
+						}else if(this.controller.multiplayer === 1){
+							p2.send("branch", "normal")
 						}
-						if(accuracy >= branch.requirement.master){
-							this.setBranch(branch, "master")
-						}else if(accuracy >= branch.requirement.advanced){
-							this.setBranch(branch, "advanced")
-						}else{
-							this.setBranch(branch, "normal")
-						}
-					}else if(this.controller.multiplayer === 1){
-						p2.send("branch", "normal")
+					}
+					if(!measure.branch){
+						this.controller.lyrics.branch = null
+					}else if(measure.branch.active){
+						this.controller.lyrics.branch = measure.branch.name
 					}
 				}
 			}
+		}
+		
+		if(this.controller.lyrics){
+			this.controller.lyrics.update(ms)
 		}
 	}
 	fixNoteStream(keysDon){

--- a/public/src/js/importsongs.js
+++ b/public/src/js/importsongs.js
@@ -37,17 +37,14 @@
 				}
 			}
 		})
-		this.assetSelectors = {
-			"bg-pattern-1": ".pattern-bg",
-			"bg_genre_0": "#song-select",
-			"title-screen": "#title-screen",
-			"dancing-don": "#loading-don",
-			"touch_drum": "#touch-drum-img",
-			"touch_fullscreen": "#touch-full-btn",
-			"touch_pause": "#touch-pause-btn",
-			"bg_stage_1": ".song-stage-1",
-			"bg_stage_2": ".song-stage-2",
-			"bg_stage_3": ".song-stage-3"
+		this.assetSelectors = {}
+		for(var selector in assets.cssBackground){
+			var filename = assets.cssBackground[selector]
+			var index = filename.lastIndexOf(".")
+			if(index !== -1){
+				filename = filename.slice(0, index)
+			}
+			this.assetSelectors[filename] = selector
 		}
 		this.comboVoices = ["v_combo_50"].concat(Array.from(Array(50), (d, i) => "v_combo_" + ((i + 1) * 100)))
 	}
@@ -64,7 +61,7 @@
 			var file = files[i]
 			var name = file.name.toLowerCase()
 			var path = file.path.toLowerCase()
-			if(name.endsWith(".tja")){
+			if(name.endsWith(".tja") || name.endsWith(".tjf")){
 				this.tjaFiles.push({
 					file: file,
 					index: i
@@ -292,9 +289,9 @@
 					if(gt === maker.length - 1){
 						var lt = maker.lastIndexOf("<")
 						if(lt !== -1 && lt !== gt - 2){
-							url = maker.slice(lt + 2, gt)
+							url = maker.slice(lt + 1, gt).trim()
 							if(url.startsWith("http://") || url.startsWith("https://")){
-								maker = maker.slice(0, lt).trim()
+								maker = maker.slice(0, lt)
 							}else{
 								url = null
 							}
@@ -452,12 +449,20 @@
 					vectors = JSON.parse(response)
 				}))
 			}
-			if(name.endsWith(".png")){
+			if(name.endsWith(".png") || name.endsWith(".gif")){
 				let image = document.createElement("img")
 				promises.push(pageEvents.load(image).then(() => {
 					if(id in this.assetSelectors){
 						var selector = this.assetSelectors[id]
-						this.stylesheet.push(selector + '{background-image:url("' + image.src + '")}')
+						var gradient = ""
+						if(selector === "#song-search"){
+							gradient = loader.songSearchGradient
+						}
+						this.stylesheet.push(loader.cssRuleset({
+							[selector]: {
+								"background-image": gradient + "url(\"" + image.src + "\")"
+							}
+						}))
 					}
 				}))
 				image.id = name

--- a/public/src/js/lyrics.js
+++ b/public/src/js/lyrics.js
@@ -131,12 +131,14 @@ class Lyrics{
 		}
 		ms += this.songOffset + this.vttOffset
 		var currentLine = this.lines[this.current]
-		while(currentLine && ms > currentLine.end){
+		while(currentLine && (ms > currentLine.end || currentLine.branch && this.branch && currentLine.branch !== this.branch)){
 			currentLine = this.lines[++this.current]
 		}
 		if(this.shown !== this.current){
 			if(currentLine && ms >= currentLine.start){
-				this.setText(this.lines[this.current].text)
+				if(!currentLine.copy){
+					this.setText(currentLine.text)
+				}
 				this.shown = this.current
 			}else if(this.shown !== -1){
 				this.setText("")

--- a/public/src/js/plugins.js
+++ b/public/src/js/plugins.js
@@ -373,6 +373,7 @@ class PluginLoader{
 				}
 			}, e => {
 				this.error()
+				plugins.remove(this.name)
 				if(e.name === "SyntaxError"){
 					var error = new SyntaxError()
 					error.stack = "Error in plugin syntax: " + this.name + "\n" + e.stack
@@ -388,7 +389,7 @@ class PluginLoader{
 			})
 		}
 	}
-	start(orderChange){
+	start(orderChange, startErrors){
 		if(!orderChange){
 			plugins.startOrder.push(this.name)
 		}
@@ -403,10 +404,15 @@ class PluginLoader{
 						this.module.start()
 					}
 				}catch(e){
+					this.error()
 					var error = new Error()
 					error.stack = "Error in plugin start: " + this.name + "\n" + e.stack
-					console.error(error)
-					this.error()
+					if(startErrors){
+						return Promise.reject(error)
+					}else{
+						console.error(error)
+						return Promise.resolve()
+					}
 				}
 			}
 		})

--- a/public/src/js/settings.js
+++ b/public/src/js/settings.js
@@ -367,7 +367,7 @@ class SettingsView{
 					if(event.target.tagName !== "SPAN"){
 						this.setValue(i)
 					}
-				})
+				}, true)
 			}else{
 				this.addTouchEnd(settingBox, event => this.setValue(i))
 			}
@@ -494,9 +494,9 @@ class SettingsView{
 				}
 				this.addTouch(settingBox, event => {
 					if(event.target.tagName !== "SPAN"){
-						this.latencySetValue(current, event.type === "touchstart")
+						this.latencySetValue(current, event.type === "touchend")
 					}
-				})
+				}, true)
 				if(current !== "calibration"){
 					outputObject.valueDiv = valueDiv
 					outputObject.valueText = valueText
@@ -543,7 +543,9 @@ class SettingsView{
 		var touchEvent = end ? "touchend" : "touchstart"
 		pageEvents.add(element, ["mousedown", touchEvent], event => {
 			if(event.type === touchEvent){
-				event.preventDefault()
+				if(event.cancelable){
+					event.preventDefault()
+				}
 				this.touched = true
 			}else if(event.which !== 1){
 				return
@@ -594,7 +596,11 @@ class SettingsView{
 		if(current.type === "language"){
 			value = allStrings[value].name + " (" + value + ")"
 		}else if(current.type === "select" || current.type === "gamepad"){
-			value = strings.settings[name][value]
+			if(current.options_lang && current.options_lang[value]){
+				value = this.getLocalTitle(value, current.options_lang[value])
+			}else if(!current.getItem){
+				value = strings.settings[name][value]
+			}
 		}else if(current.type === "toggle"){
 			value = value ? strings.settings.on : strings.settings.off
 		}else if(current.type === "keyboard"){

--- a/public/src/js/songselect.js
+++ b/public/src/js/songselect.js
@@ -412,7 +412,7 @@ class SongSelect{
 		if(name === "ctrl" || name === "shift" || !this.redrawRunning){
 			return
 		}
-		var ctrl = this.pressedKeys["ctrl"] || this.pressedKeys["ctrlGamepad"]
+		var ctrl = event ? event.ctrlKey : (this.pressedKeys["ctrl"] || this.pressedKeys["ctrlGamepad"])
 		var shift = event ? event.shiftKey : this.pressedKeys["shift"]
 		if(this.state.showWarning){
 			if(name === "confirm"){
@@ -1076,12 +1076,13 @@ class SongSelect{
 			this.selectableText = ""
 			
 			if(this.search.opened && this.search.container){
-				this.search.onInput()
+				this.search.onInput(true)
 			}
 		}else if(!document.hasFocus() && !p2.session){
 			if(this.state.focused){
 				this.state.focused = false
 				this.songSelect.classList.add("unfocused")
+				this.pressedKeys = {}
 			}
 			return
 		}else{
@@ -2046,7 +2047,8 @@ class SongSelect{
 						fontSize: 40,
 						fontFamily: this.font,
 						selectable: this.selectable,
-						selectableScale: this.ratio / this.pixelRatio
+						selectableScale: this.ratio / this.pixelRatio,
+						selectableX: Math.max(0, innerWidth / 2 - lastHeight * 16 / 9)
 					})
 					this.selectable.style.display = ""
 					this.selectableText = currentSong.title

--- a/public/src/js/titlescreen.js
+++ b/public/src/js/titlescreen.js
@@ -101,7 +101,7 @@ class Titlescreen{
 					}).then(() => {
 						if(noError){
 							setTimeout(() => {
-								new SongSelect("customSongs", false, this.touchEnabled)
+								new SongSelect("customSongs", false, this.touched)
 							}, 500)
 						}
 					})

--- a/public/src/js/view.js
+++ b/public/src/js/view.js
@@ -255,10 +255,6 @@
 			this.setDonBgHeight()
 		}
 		
-		if(this.controller.lyrics){
-			this.controller.lyrics.update(ms)
-		}
-		
 		ctx.save()
 		ctx.translate(0, frameTop)
 		


### PR DESCRIPTION
- #LYRIC
  - Parse #LYRIC commands and apply them to all difficulties that do not have them
  - #LYRIC command now supports branches
  - Fix last #LYRIC at the end of the chart getting ignored
- Fix the glitchy dragging and dropping of files on the custom song importing page
- Fix Ctrl and Shift keys getting stuck on song select when switching tabs with Ctrl(+Shift)+Tab
- Search
  - Fix the search box "random:yes" query to randomize the entire results and not just the first 50
  - Add "all:yes" query to the search box to remove the result limit and display all of the results
  - Fix searching for an invalid query (like "cleared:yes" or ":") unexpectedly returning all the songs
  - Fix pressing Q then jumping to a song through search not unmuting the sound
  - Pressing the search key on mobile will hide the keyboard
  - Fix search tips changing rapidly when the window is resized
- Use comments instead of `######` in the issue template so that the warning does not appear in the issue
- Fix TJA MAKER: url between angle brackets not working
- Add a check for Class field declarations in the browser support warning
- Fix gpicker getting stuck if a network error occurs
- Fix not being able to replace some assets using a "taiko-web assets" folder
- Fix selectable song title not being aligned with the game if the game window is too wide
- Allow plugin developers to use the "select" type for the settings options
  - It uses "options" array and "options_lang" object
- Fix plugins not getting removed from the plugin list on syntax error
- Fix error messages not working if a default plugin is broken
- Fix the start of default plugins not stopping the page from loading on error
- Fix not being able to scroll the plugins screen on mobile