### PR TITLE
Add .webmanifest for iOS

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,3 @@
+{
+	"display": "standalone"
+}

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,0 @@
-{"display":"standalone"}

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,1 @@
+{"display":"standalone"}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
 	<meta name="color-scheme" content="only light">
 
 	<link rel="stylesheet" href="src/css/loader.css?{{version.commit_short}}">
-	<link rel="manifest" href="/site.webmanifest" />
+	<link rel="manifest" href="manifest.json">
 
 	<script src="src/js/assets.js?{{version.commit_short}}"></script>
 	<script src="src/js/strings.js?{{version.commit_short}}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,7 @@
 	<meta name="color-scheme" content="only light">
 
 	<link rel="stylesheet" href="src/css/loader.css?{{version.commit_short}}">
+	<link rel="manifest" href="/site.webmanifest" />
 
 	<script src="src/js/assets.js?{{version.commit_short}}"></script>
 	<script src="src/js/strings.js?{{version.commit_short}}"></script>


### PR DESCRIPTION
Safari on iOS device accepts a page that runs in PWA mode. So If we add a `.webmanifest` file and link it to html, it can be run on fullscreen (by adding a bookmark to iOS home screen).
(It's my first PR on GitHub, sorry if there is any improper.)